### PR TITLE
Improve sparse issue enrichment grounding

### DIFF
--- a/.github/issue-enrichment/prompt.md
+++ b/.github/issue-enrichment/prompt.md
@@ -4,13 +4,20 @@ Turn a short intake into a clearer ticket for later human review.
 
 Rules:
 - Use ONLY the information present in the intake payload.
+- Ground the output first in `normalizedFields.shortDescription`, `normalizedFields.desiredOutcome`, `normalizedFields.context`, and `sourceSignals.anchorPhrases`.
+- Reuse the intake's most concrete product words when they already name the request well.
 - Do NOT invent users, deadlines, implementation details, metrics, or certainty.
+- Do NOT add UI, documentation, performance, accessibility, localization, analytics, or rollout requirements unless the intake explicitly points there.
+- If `sourceSignals.detailLevel` is `minimal`, keep the scope tight and literal. Do not turn a two-word idea into a repo-wide initiative.
+- Prefer the narrowest concrete interpretation that fits the intake. Example: if the intake says `busqueda avanzada`, stay close to `advanced search` instead of generic phrases like `improve search experience`.
 - If the source is sparse, say so explicitly in `caveats` and `openQuestions`.
 - Keep the enriched title specific, neutral, and reviewable.
 - Write concise product-language prose, not implementation instructions.
 - Keep `summary`, `problem`, and `desiredOutcome` to one short paragraph each.
-- Acceptance criteria should describe reviewable outcomes, not code tasks, and each item should be short enough to read comfortably in a checklist.
+- Acceptance criteria should describe reviewable outcomes, not code tasks. Tie them to the literal request and avoid filler criteria that are not supported by the intake.
+- For sparse inputs, prefer 2-3 checklist items that stay close to the stated request.
 - Keep `caveats` and `openQuestions` short, literal, and easy to scan as bullets.
+- Use `openQuestions` for the most important missing decisions that block confident planning, not for speculative brainstorming.
 - Optimize for deterministic, low-flair wording suitable for a sober professional issue body.
 - Choose the closest `type` from the allowed enum.
 - Only assign `priority` when urgency is reasonably implied; otherwise use `unspecified`.

--- a/.github/scripts/enrich-issue.mjs
+++ b/.github/scripts/enrich-issue.mjs
@@ -44,6 +44,13 @@ const REPOSITORY_LABEL_DEFINITIONS = [
 const ALLOWED_TYPES = new Set(Object.keys(TYPE_LABELS));
 const ALLOWED_PRIORITIES = new Set(["high", "medium", "low", "unspecified"]);
 const MANAGED_LABEL_PREFIXES = ["triage:", "type:", "priority:"];
+const EMPTY_FIELD_VALUES = new Set(["_No response_", "_No original body was provided._"]);
+const NORMALIZED_SECTION_KEYS = {
+  "what is this?": "kind",
+  "short description": "shortDescription",
+  "desired outcome": "desiredOutcome",
+  "context or link": "context",
+};
 
 function getRequiredEnv(name) {
   const value = process.env[name];
@@ -120,8 +127,114 @@ function parseFormSections(markdown) {
   return sections;
 }
 
+function normalizeOptionalText(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  const trimmed = value.trim();
+  return EMPTY_FIELD_VALUES.has(trimmed) ? "" : trimmed;
+}
+
+function normalizeFormSections(sections) {
+  const normalized = {
+    kind: "",
+    shortDescription: "",
+    desiredOutcome: "",
+    context: "",
+    extraSections: {},
+  };
+
+  for (const [heading, value] of Object.entries(sections)) {
+    const normalizedValue = normalizeOptionalText(value);
+
+    if (!normalizedValue) {
+      continue;
+    }
+
+    const normalizedKey = NORMALIZED_SECTION_KEYS[heading.trim().toLowerCase()];
+
+    if (normalizedKey) {
+      normalized[normalizedKey] = normalizedValue;
+      continue;
+    }
+
+    normalized.extraSections[heading] = normalizedValue;
+  }
+
+  return normalized;
+}
+
+function stripIntakePrefix(title) {
+  return title.replace(/^\[intake\]\s*/i, "").trim();
+}
+
+function splitPhraseCandidates(text) {
+  return text
+    .split(/[\n,;|]+/)
+    .map((part) => part.replace(/^[\-:*\s]+|[\-:*\s]+$/g, "").trim())
+    .filter(Boolean);
+}
+
+function extractAnchorPhrases(rawIntake, normalizedFields) {
+  const candidates = [
+    normalizedFields.shortDescription,
+    normalizedFields.desiredOutcome,
+    normalizedFields.context,
+    stripIntakePrefix(rawIntake.title),
+  ];
+
+  const unique = new Set();
+
+  for (const candidate of candidates) {
+    const normalizedCandidate = normalizeOptionalText(candidate);
+
+    if (!normalizedCandidate) {
+      continue;
+    }
+
+    for (const phrase of splitPhraseCandidates(normalizedCandidate)) {
+      if (phrase.length < 3 || phrase.length > 80) {
+        continue;
+      }
+
+      unique.add(phrase);
+    }
+  }
+
+  return [...unique].slice(0, 6);
+}
+
+function buildSourceSignals(rawIntake, normalizedFields) {
+  const populatedFields = [
+    normalizedFields.kind,
+    normalizedFields.shortDescription,
+    normalizedFields.desiredOutcome,
+    normalizedFields.context,
+  ].filter(Boolean);
+  const shortDescriptionWordCount = normalizedFields.shortDescription
+    ? normalizedFields.shortDescription.split(/\s+/).filter(Boolean).length
+    : 0;
+  const detailLevel =
+    populatedFields.length <= 2 && shortDescriptionWordCount <= 4
+      ? "minimal"
+      : populatedFields.length <= 3
+        ? "moderate"
+        : "detailed";
+
+  return {
+    detailLevel,
+    populatedFieldCount: populatedFields.length,
+    hasDesiredOutcome: Boolean(normalizedFields.desiredOutcome),
+    hasContext: Boolean(normalizedFields.context),
+    titleWithoutPrefix: stripIntakePrefix(rawIntake.title),
+    anchorPhrases: extractAnchorPhrases(rawIntake, normalizedFields),
+  };
+}
+
 function buildModelPayload(issue, rawIntake) {
   const sections = parseFormSections(rawIntake.body);
+  const normalizedFields = normalizeFormSections(sections);
 
   return {
     repository: process.env.GITHUB_REPOSITORY,
@@ -131,6 +244,8 @@ function buildModelPayload(issue, rawIntake) {
     rawTitle: rawIntake.title,
     rawBody: rawIntake.body,
     parsedSections: sections,
+    normalizedFields,
+    sourceSignals: buildSourceSignals(rawIntake, normalizedFields),
   };
 }
 

--- a/.github/workflows/issue-enrichment.yml
+++ b/.github/workflows/issue-enrichment.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
 


### PR DESCRIPTION
## Summary
- tighten the issue-enrichment prompt so very short intakes stay grounded in the literal source language instead of expanding into generic repo-wide tickets
- add normalized intake fields and sparse-input signals to the model payload so short ideas like issue #3 produce more concrete titles, checklists, and open questions without inventing certainty
- bump `actions/checkout` and `actions/setup-node` to `v5` to stay ahead of Node 24 action runtime deprecation warnings

## Checks
- `node --check .github/scripts/enrich-issue.mjs`
- `DRY_RUN=1 GITHUB_EVENT_PATH=.github/issue-enrichment/examples/sample-issue-event.json GITHUB_REPOSITORY=Carlos11932/rollorian-books GITHUB_EVENT_NAME=issues GITHUB_ACTOR=Carlos11932 MOCK_MODEL_RESPONSE_PATH=.github/issue-enrichment/examples/sample-model-response.json node .github/scripts/enrich-issue.mjs`
- `npx eslint .github/scripts/enrich-issue.mjs`
- `git diff --check`