### PR TITLE
fix: avoid recreating issue enrichment labels

### DIFF
--- a/.github/scripts/enrich-issue.mjs
+++ b/.github/scripts/enrich-issue.mjs
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
 
 const MANAGED_MARKER = "<!-- issue-enrichment:managed -->";
 const RAW_START_MARKER = "<!-- issue-enrichment:raw:start -->";
@@ -398,21 +399,44 @@ async function githubRequest(path, { method = "GET", body } = {}) {
 
   if (!response.ok) {
     const message = parsed?.message || raw || `${response.status} ${response.statusText}`;
-    throw new Error(`GitHub API request failed (${method} ${path}): ${message}`);
+    const error = new Error(`GitHub API request failed (${method} ${path}): ${message}`);
+    error.status = response.status;
+    error.details = parsed;
+    throw error;
   }
 
   return parsed;
 }
 
+function getMissingRepositoryLabels(existingLabelNames) {
+  const existing = new Set(existingLabelNames);
+  return REPOSITORY_LABEL_DEFINITIONS.filter((label) => !existing.has(label.name));
+}
+
+function isLabelAlreadyExistsError(error) {
+  const alreadyExists = error?.details?.errors?.some(
+    (detail) => detail?.code === "already_exists" && (!detail?.resource || detail.resource === "Label")
+  );
+
+  return alreadyExists || String(error?.message).includes("already_exists");
+}
+
+async function fetchRepositoryLabelNames(repository) {
+  const labels = await githubRequest(`/repos/${repository}/labels?per_page=100`);
+  return labels.map((label) => label.name);
+}
+
 async function ensureRepositoryLabels(repository) {
-  for (const label of REPOSITORY_LABEL_DEFINITIONS) {
+  const existingLabelNames = await fetchRepositoryLabelNames(repository);
+
+  for (const label of getMissingRepositoryLabels(existingLabelNames)) {
     try {
       await githubRequest(`/repos/${repository}/labels`, {
         method: "POST",
         body: label,
       });
     } catch (error) {
-      if (!String(error.message).includes("already_exists")) {
+      if (!isLabelAlreadyExistsError(error)) {
         throw error;
       }
     }
@@ -567,7 +591,15 @@ async function main() {
   console.log(`Enriched issue #${issueNumber} with labels: ${nextLabels.join(", ")}`);
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : error);
-  process.exitCode = 1;
-});
+const isDirectExecution = process.argv[1]
+  ? import.meta.url === pathToFileURL(process.argv[1]).href
+  : false;
+
+if (isDirectExecution) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}
+
+export { getMissingRepositoryLabels, isLabelAlreadyExistsError };

--- a/.github/scripts/enrich-issue.test.mjs
+++ b/.github/scripts/enrich-issue.test.mjs
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  getMissingRepositoryLabels,
+  isLabelAlreadyExistsError,
+} from "./enrich-issue.mjs";
+
+test("getMissingRepositoryLabels only returns labels that do not exist yet", () => {
+  const missing = getMissingRepositoryLabels([
+    "triage:raw",
+    "triage:enriched",
+    "type:feature",
+    "priority:medium",
+  ]);
+
+  assert.deepEqual(
+    missing.map((label) => label.name),
+    [
+      "triage:rerun",
+      "type:bug",
+      "type:content",
+      "type:research",
+      "type:chore",
+      "type:needs-review",
+      "priority:high",
+      "priority:low",
+    ]
+  );
+});
+
+test("isLabelAlreadyExistsError treats GitHub validation errors as non-fatal duplicates", () => {
+  const error = new Error("Validation Failed");
+  error.status = 422;
+  error.details = {
+    message: "Validation Failed",
+    errors: [
+      {
+        resource: "Label",
+        code: "already_exists",
+        field: "name",
+      },
+    ],
+  };
+
+  assert.equal(isLabelAlreadyExistsError(error), true);
+});


### PR DESCRIPTION
## Summary
- fetch existing repository labels before bootstrap so the issue enrichment workflow only creates labels that are actually missing
- keep a defensive fallback for GitHub's `422 Validation Failed` duplicate-label response when concurrent runs race on label creation
- add a focused regression test for missing-label detection and duplicate-label error handling

## Verification
- `node --test .github/scripts/enrich-issue.test.mjs`
- `npx eslint .github/scripts/enrich-issue.mjs .github/scripts/enrich-issue.test.mjs`
- `env DRY_RUN=1 GITHUB_EVENT_PATH=.github/issue-enrichment/examples/sample-issue-event.json GITHUB_EVENT_NAME=issues GITHUB_REPOSITORY=Carlos11932/rollorian-books GITHUB_ACTOR=Carlos11932 MOCK_MODEL_RESPONSE_PATH=.github/issue-enrichment/examples/sample-model-response.json node .github/scripts/enrich-issue.mjs`