### PR TITLE
fix: preserve opened issue enrichment run

### DIFF
--- a/.github/workflows/issue-enrichment.yml
+++ b/.github/workflows/issue-enrichment.yml
@@ -6,7 +6,7 @@ on:
 
 concurrency:
   group: issue-enrichment-${{ github.event.issue.number }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event.action == 'labeled' && github.event.label.name == 'triage:rerun' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- keep the initial `issues.opened` enrichment run alive by only enabling concurrency cancellation for manual `triage:rerun` label events
- preserve manual rerun support on `issues.labeled` without letting automatic `triage:raw` labeling cancel the useful run

## Verification
- parsed `.github/workflows/issue-enrichment.yml` locally with Ruby `YAML.load_file(...)`
- confirmed the PR diff is limited to the workflow concurrency setting
- `actionlint` is not installed in the local environment, so that check could not be run here