### PR TITLE
fix: revalidate home after book mutations

### DIFF
--- a/src/app/api/books/[id]/__tests__/route.test.ts
+++ b/src/app/api/books/[id]/__tests__/route.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { BookStatus, type Book } from "@/lib/types/book";
 
+const { revalidatePathMock } = vi.hoisted(() => ({
+  revalidatePathMock: vi.fn(),
+}));
+
 // Mock prisma BEFORE importing the route so the module initialiser never
 // tries to connect to the database.
 vi.mock("@/lib/prisma", () => ({
@@ -13,6 +17,10 @@ vi.mock("@/lib/prisma", () => ({
       delete: vi.fn(),
     },
   },
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: revalidatePathMock,
 }));
 
 // Import after mocks are established.
@@ -107,6 +115,9 @@ describe("PATCH /api/books/[id]", () => {
     const json: unknown = await response.json();
     expect((json as Book).status).toBe(BookStatus.READ);
     expect(prismaMock.update).toHaveBeenCalledOnce();
+    expect(revalidatePathMock).toHaveBeenCalledWith("/");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/library");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/books/book-123");
   });
 
   it("returns 200 when body is empty (no-op update — all fields are optional)", async () => {
@@ -214,6 +225,9 @@ describe("DELETE /api/books/[id]", () => {
     expect(response.body).toBeNull();
     expect(prismaMock.delete).toHaveBeenCalledOnce();
     expect(prismaMock.delete).toHaveBeenCalledWith({ where: { id: "book-123" } });
+    expect(revalidatePathMock).toHaveBeenCalledWith("/");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/library");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/books/book-123");
   });
 
   it("returns 404 when the book does not exist", async () => {

--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -10,6 +10,12 @@ type RouteContext = {
   params: Promise<{ id: string }>;
 };
 
+function revalidateBookCollectionPaths(bookId: string) {
+  revalidatePath("/");
+  revalidatePath("/library");
+  revalidatePath(`/books/${bookId}`);
+}
+
 export async function GET(
   _request: NextRequest,
   { params }: RouteContext
@@ -57,9 +63,7 @@ export async function PATCH(
       data: result.data,
     });
 
-    revalidatePath('/');
-    revalidatePath('/library');
-    revalidatePath(`/books/${id}`);
+    revalidateBookCollectionPaths(id);
 
     return Response.json(book);
   } catch (error) {
@@ -82,8 +86,7 @@ export async function DELETE(
 
     await prisma.book.delete({ where: { id } });
 
-    revalidatePath('/');
-    revalidatePath('/library');
+    revalidateBookCollectionPaths(id);
 
     return new Response(null, { status: 204 });
   } catch (error) {

--- a/src/app/api/books/__tests__/route.test.ts
+++ b/src/app/api/books/__tests__/route.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { BookStatus, type Book } from "@/lib/types/book";
 
+const { revalidatePathMock } = vi.hoisted(() => ({
+  revalidatePathMock: vi.fn(),
+}));
+
 // Mock prisma BEFORE importing the route so the module initialiser never
 // tries to connect to the database.
 vi.mock("@/lib/prisma", () => ({
@@ -13,6 +17,10 @@ vi.mock("@/lib/prisma", () => ({
       delete: vi.fn(),
     },
   },
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: revalidatePathMock,
 }));
 
 // Import after mocks are established.
@@ -94,6 +102,9 @@ describe("POST /api/books", () => {
     const json: unknown = await response.json();
     expect((json as { id: string }).id).toBe("book-001");
     expect(prismaMock.create).toHaveBeenCalledOnce();
+    expect(revalidatePathMock).toHaveBeenCalledWith("/");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/library");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/books/book-001");
   });
 
   it("returns 400 when title is missing", async () => {

--- a/src/app/api/books/route.ts
+++ b/src/app/api/books/route.ts
@@ -12,6 +12,12 @@ function isBookStatus(value: string): value is BookStatus {
   return VALID_STATUSES.has(value);
 }
 
+function revalidateBookCollectionPaths(bookId: string) {
+  revalidatePath("/");
+  revalidatePath("/library");
+  revalidatePath(`/books/${bookId}`);
+}
+
 export async function GET(request: NextRequest): Promise<Response> {
   try {
     const searchParams = request.nextUrl.searchParams;
@@ -67,8 +73,7 @@ export async function POST(request: NextRequest): Promise<Response> {
       data: result.data,
     });
 
-    revalidatePath('/');
-    revalidatePath('/library');
+    revalidateBookCollectionPaths(book.id);
 
     return Response.json(book, { status: 201 });
   } catch (error) {


### PR DESCRIPTION
## Summary
- invalidate Home, Library, and detail routes after book create/update/delete mutations so server-rendered rails stop showing stale entries
- keep the cache revalidation logic centralized in the books API handlers and extend the route tests to cover the new invalidation contract
- preserve the latest `main` changes by resolving the merge conflict in the feature branch before opening this PR

## Testing
- npx tsc --noEmit
- npm test -- src/app/api/books/__tests__/route.test.ts "src/app/api/books/[id]/__tests__/route.test.ts"
- npm run lint