### PR TITLE
feat: loan system — borrow/lend books between connections

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -308,6 +308,24 @@
     "noData": "No reading data yet",
     "startReading": "Add some books to see your stats"
   },
+  "loans": {
+    "lentTo": "Lent to {name}",
+    "borrowedFrom": "Borrowed from {name}",
+    "requestLoan": "Request to borrow",
+    "offerLoan": "Offer to lend",
+    "accept": "Accept",
+    "decline": "Decline",
+    "return": "Return",
+    "pending": "Pending",
+    "active": "Active",
+    "requestedBy": "{name} wants to borrow this book",
+    "offeredBy": "{name} is offering you this book",
+    "lentBooks": "Books you lent",
+    "borrowedBooks": "Books borrowed",
+    "noLoans": "No active loans",
+    "requesting": "Requesting...",
+    "offering": "Offering..."
+  },
   "people": {
     "heading": "People",
     "description": "Find readers and discover what they're reading.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -308,6 +308,24 @@
     "noData": "Aún no hay datos de lectura",
     "startReading": "Añade libros para ver tus estadísticas"
   },
+  "loans": {
+    "lentTo": "Prestado a {name}",
+    "borrowedFrom": "Prestado por {name}",
+    "requestLoan": "Pedir prestado",
+    "offerLoan": "Ofrecer prestar",
+    "accept": "Aceptar",
+    "decline": "Rechazar",
+    "return": "Devolver",
+    "pending": "Pendiente",
+    "active": "Activo",
+    "requestedBy": "{name} quiere que le prestes este libro",
+    "offeredBy": "{name} te ofrece prestar este libro",
+    "lentBooks": "Libros prestados",
+    "borrowedBooks": "Te han prestado",
+    "noLoans": "No tienes préstamos activos",
+    "requesting": "Solicitando...",
+    "offering": "Ofreciendo..."
+  },
   "people": {
     "heading": "Personas",
     "description": "Encuentra lectores y descubre qué están leyendo.",

--- a/prisma/migrations/20260401100000_add_loans/migration.sql
+++ b/prisma/migrations/20260401100000_add_loans/migration.sql
@@ -1,0 +1,26 @@
+-- CreateEnum
+CREATE TYPE "LoanStatus" AS ENUM ('REQUESTED', 'OFFERED', 'ACTIVE', 'RETURNED', 'DECLINED');
+
+-- CreateTable
+CREATE TABLE "Loan" (
+    "id" TEXT NOT NULL,
+    "lenderId" TEXT NOT NULL,
+    "borrowerId" TEXT NOT NULL,
+    "bookId" TEXT NOT NULL,
+    "status" "LoanStatus" NOT NULL DEFAULT 'REQUESTED',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Loan_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Loan_lenderId_borrowerId_bookId_key" ON "Loan"("lenderId", "borrowerId", "bookId");
+CREATE INDEX "Loan_lenderId_status_idx" ON "Loan"("lenderId", "status");
+CREATE INDEX "Loan_borrowerId_status_idx" ON "Loan"("borrowerId", "status");
+CREATE INDEX "Loan_bookId_idx" ON "Loan"("bookId");
+
+-- AddForeignKey
+ALTER TABLE "Loan" ADD CONSTRAINT "Loan_lenderId_fkey" FOREIGN KEY ("lenderId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Loan" ADD CONSTRAINT "Loan_borrowerId_fkey" FOREIGN KEY ("borrowerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Loan" ADD CONSTRAINT "Loan_bookId_fkey" FOREIGN KEY ("bookId") REFERENCES "Book"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,6 +53,8 @@ model User {
   followers     Follow[]      @relation("following")
   following     Follow[]      @relation("followers")
   bookLists     BookList[]
+  loansGiven    Loan[]        @relation("lender")
+  loansReceived Loan[]        @relation("borrower")
 }
 
 model Group {
@@ -157,8 +159,35 @@ model Book {
   updatedAt     DateTime       @updatedAt
   userBooks     UserBook[]
   listItems     BookListItem[]
+  loans         Loan[]
 
   @@index([createdAt])
+}
+
+enum LoanStatus {
+  REQUESTED
+  OFFERED
+  ACTIVE
+  RETURNED
+  DECLINED
+}
+
+model Loan {
+  id         String     @id @default(cuid())
+  lenderId   String
+  borrowerId String
+  bookId     String
+  status     LoanStatus @default(REQUESTED)
+  createdAt  DateTime   @default(now())
+  updatedAt  DateTime   @updatedAt
+  lender     User       @relation("lender", fields: [lenderId], references: [id], onDelete: Cascade)
+  borrower   User       @relation("borrower", fields: [borrowerId], references: [id], onDelete: Cascade)
+  book       Book       @relation(fields: [bookId], references: [id], onDelete: Cascade)
+
+  @@unique([lenderId, borrowerId, bookId])
+  @@index([lenderId, status])
+  @@index([borrowerId, status])
+  @@index([bookId])
 }
 
 model UserBook {

--- a/src/app/api/loans/[id]/route.ts
+++ b/src/app/api/loans/[id]/route.ts
@@ -1,0 +1,60 @@
+import "server-only";
+
+import type { NextRequest } from "next/server";
+import { requireAuth, UnauthorizedError } from "@/lib/auth/require-auth";
+import {
+  acceptLoan,
+  declineLoan,
+  returnLoan,
+  LoanNotFoundError,
+  LoanForbiddenError,
+  LoanInvalidTransitionError,
+} from "@/lib/loans";
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  try {
+    const { userId } = await requireAuth();
+    const { id } = await params;
+    const body = (await request.json()) as { action: "accept" | "decline" | "return" };
+
+    if (!body.action) {
+      return Response.json({ error: "Missing action" }, { status: 400 });
+    }
+
+    let loan;
+    switch (body.action) {
+      case "accept":
+        loan = await acceptLoan(id, userId);
+        break;
+      case "decline":
+        loan = await declineLoan(id, userId);
+        break;
+      case "return":
+        loan = await returnLoan(id, userId);
+        break;
+      default:
+        return Response.json({ error: "Invalid action" }, { status: 400 });
+    }
+
+    return Response.json(loan);
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (error instanceof LoanNotFoundError) {
+      return Response.json({ error: error.message }, { status: 404 });
+    }
+    if (error instanceof LoanForbiddenError) {
+      return Response.json({ error: error.message }, { status: 403 });
+    }
+    if (error instanceof LoanInvalidTransitionError) {
+      return Response.json({ error: error.message }, { status: 400 });
+    }
+    const message = error instanceof Error ? error.message : "Internal server error";
+    console.error("[PATCH /api/loans/:id]", error);
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/loans/route.ts
+++ b/src/app/api/loans/route.ts
@@ -1,0 +1,55 @@
+import "server-only";
+
+import type { NextRequest } from "next/server";
+import { requireAuth, UnauthorizedError } from "@/lib/auth/require-auth";
+import {
+  getUserLoans,
+  requestLoan,
+  offerLoan,
+  LoanBookNotInLibraryError,
+} from "@/lib/loans";
+
+export async function GET(): Promise<Response> {
+  try {
+    const { userId } = await requireAuth();
+    const loans = await getUserLoans(userId);
+    return Response.json({ loans });
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    console.error("[GET /api/loans]", error);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest): Promise<Response> {
+  try {
+    const { userId } = await requireAuth();
+    const body = (await request.json()) as {
+      type: "request" | "offer";
+      targetUserId: string;
+      bookId: string;
+    };
+
+    if (!body.type || !body.targetUserId || !body.bookId) {
+      return Response.json({ error: "Missing type, targetUserId, or bookId" }, { status: 400 });
+    }
+
+    const loan = body.type === "request"
+      ? await requestLoan(userId, body.targetUserId, body.bookId)
+      : await offerLoan(userId, body.targetUserId, body.bookId);
+
+    return Response.json(loan, { status: 201 });
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (error instanceof LoanBookNotInLibraryError) {
+      return Response.json({ error: error.message }, { status: 400 });
+    }
+    const message = error instanceof Error ? error.message : "Internal server error";
+    console.error("[POST /api/loans]", error);
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import { ReadingHero } from "@/features/dashboard/components/reading-hero";
 import { DashboardBookRail } from "@/features/dashboard/components/dashboard-book-rail";
 import { DashboardStats } from "@/features/dashboard/components/dashboard-stats";
 import { DashboardRecommendations } from "@/features/dashboard/components/dashboard-recommendations";
+import { DashboardLoans } from "@/features/loans/components/dashboard-loans";
 
 export default async function Home() {
   const t = await getTranslations();
@@ -68,7 +69,10 @@ export default async function Home() {
       {/* 2. Quick Stats */}
       <DashboardStats />
 
-      {/* 3. Recommendations (client-side fetch) */}
+      {/* 3. Active loans */}
+      <DashboardLoans />
+
+      {/* 4. Recommendations (client-side fetch) */}
       <DashboardRecommendations />
 
       {/* 4. Up Next — TO_READ */}

--- a/src/features/books/components/discovered-book-detail.tsx
+++ b/src/features/books/components/discovered-book-detail.tsx
@@ -7,6 +7,7 @@ import { BookCover } from "@/features/books/components/book-cover";
 import { MetadataCard } from "@/features/books/components/metadata-card";
 import { BlurredBackground } from "@/features/shared/components/blurred-background";
 import { GoogleBookSaveClient } from "@/features/books/components/google-book-save-client";
+import { RequestLoanButton } from "@/features/loans/components/request-loan-button";
 import type { BookOwner } from "@/app/books/[id]/page";
 
 interface DiscoveredBookDetailProps {
@@ -108,36 +109,38 @@ export async function DiscoveredBookDetail({ book, owners }: DiscoveredBookDetai
             </div>
             <div className="flex flex-wrap gap-3">
               {owners.map((owner) => (
-                <Link
+                <div
                   key={owner.userId}
-                  href={`/users/${owner.userId}`}
-                  className="flex items-center gap-3 rounded-xl border border-outline-variant/15 bg-surface-container-low/40 px-4 py-3 hover:border-primary/30 transition-colors"
+                  className="flex items-center gap-3 rounded-xl border border-outline-variant/15 bg-surface-container-low/40 px-4 py-3"
                 >
-                  {owner.userImage ? (
-                    <Image
-                      src={owner.userImage}
-                      alt={owner.userName ?? ""}
-                      width={32}
-                      height={32}
-                      className="rounded-full object-cover w-8 h-8 shrink-0"
-                    />
-                  ) : (
-                    <div className="w-8 h-8 rounded-full bg-primary-container flex items-center justify-center shrink-0">
-                      <span className="material-symbols-outlined text-primary text-sm">person</span>
+                  <Link href={`/users/${owner.userId}`} className="flex items-center gap-3 flex-1 min-w-0 hover:opacity-80 transition-opacity">
+                    {owner.userImage ? (
+                      <Image
+                        src={owner.userImage}
+                        alt={owner.userName ?? ""}
+                        width={32}
+                        height={32}
+                        className="rounded-full object-cover w-8 h-8 shrink-0"
+                      />
+                    ) : (
+                      <div className="w-8 h-8 rounded-full bg-primary-container flex items-center justify-center shrink-0">
+                        <span className="material-symbols-outlined text-primary text-sm">person</span>
+                      </div>
+                    )}
+                    <div className="min-w-0">
+                      <p className="text-sm font-semibold text-on-surface truncate">
+                        {owner.userName ?? "Anonymous"}
+                      </p>
+                      <p className="text-[10px] text-tertiary">
+                        {t(`book.status.${owner.status}`)}
+                        {owner.rating != null && (
+                          <span className="ml-1">· ⭐ {owner.rating}</span>
+                        )}
+                      </p>
                     </div>
-                  )}
-                  <div>
-                    <p className="text-sm font-semibold text-on-surface">
-                      {owner.userName ?? "Anonymous"}
-                    </p>
-                    <p className="text-[10px] text-tertiary">
-                      {t(`book.status.${owner.status}`)}
-                      {owner.rating != null && (
-                        <span className="ml-1">· ⭐ {owner.rating}</span>
-                      )}
-                    </p>
-                  </div>
-                </Link>
+                  </Link>
+                  <RequestLoanButton lenderId={owner.userId} bookId={book.id} />
+                </div>
               ))}
             </div>
           </section>

--- a/src/features/loans/components/dashboard-loans.tsx
+++ b/src/features/loans/components/dashboard-loans.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { Button } from "@/features/shared/components/button";
+import type { LoanView } from "@/lib/loans";
+
+export function DashboardLoans() {
+  const t = useTranslations("loans");
+  const [loans, setLoans] = useState<LoanView[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    void fetch("/api/loans")
+      .then((res) => (res.ok ? (res.json() as Promise<{ loans: LoanView[] }>) : { loans: [] }))
+      .then((data) => setLoans(data.loans))
+      .catch(() => {})
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  async function handleAction(loanId: string, action: "accept" | "decline" | "return") {
+    const res = await fetch(`/api/loans/${loanId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action }),
+    });
+
+    if (res.ok) {
+      // Remove from list (accepted becomes active, decline/return removes)
+      if (action === "decline" || action === "return") {
+        setLoans((prev) => prev.filter((l) => l.id !== loanId));
+      } else {
+        const updated = (await res.json()) as LoanView;
+        setLoans((prev) => prev.map((l) => (l.id === loanId ? updated : l)));
+      }
+    }
+  }
+
+  if (isLoading || loans.length === 0) return null;
+
+  return (
+    <section>
+      <div className="flex items-center gap-2 mb-4">
+        <span
+          className="material-symbols-outlined text-primary text-[20px]"
+          style={{ fontVariationSettings: "'FILL' 1" }}
+        >
+          swap_horiz
+        </span>
+        <h2 className="text-lg font-bold text-on-surface">{t("lentBooks")}</h2>
+      </div>
+
+      <div className="grid gap-3">
+        {loans.map((loan) => (
+          <div
+            key={loan.id}
+            className="flex items-center gap-4 rounded-[var(--radius-xl)] border border-outline-variant/15 bg-surface-container-low/40 p-4"
+            style={{ backdropFilter: "blur(8px)" }}
+          >
+            {/* Book cover */}
+            <Link href={`/books/${loan.bookId}`} className="shrink-0">
+              {loan.bookCoverUrl ? (
+                <Image
+                  src={loan.bookCoverUrl}
+                  alt={loan.bookTitle}
+                  width={40}
+                  height={60}
+                  className="rounded-md object-cover w-10 h-[60px]"
+                />
+              ) : (
+                <div className="w-10 h-[60px] rounded-md bg-surface-container flex items-center justify-center">
+                  <span className="material-symbols-outlined text-tertiary text-lg">menu_book</span>
+                </div>
+              )}
+            </Link>
+
+            {/* Info */}
+            <div className="flex-1 min-w-0">
+              <Link href={`/books/${loan.bookId}`} className="hover:text-primary transition-colors">
+                <p className="text-sm font-bold text-on-surface truncate">{loan.bookTitle}</p>
+              </Link>
+              <p className="text-[11px] text-tertiary truncate">
+                {loan.bookAuthors.join(", ")}
+              </p>
+              <p className="text-[10px] text-tertiary mt-0.5">
+                {loan.status === "REQUESTED" || loan.status === "OFFERED"
+                  ? t("pending")
+                  : t("active")}
+                {" · "}
+                {loan.lenderName ?? "?"} → {loan.borrowerName ?? "?"}
+              </p>
+            </div>
+
+            {/* Actions */}
+            <div className="flex gap-2 shrink-0">
+              {(loan.status === "REQUESTED" || loan.status === "OFFERED") && (
+                <>
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    onClick={() => void handleAction(loan.id, "accept")}
+                  >
+                    {t("accept")}
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => void handleAction(loan.id, "decline")}
+                  >
+                    {t("decline")}
+                  </Button>
+                </>
+              )}
+              {loan.status === "ACTIVE" && (
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => void handleAction(loan.id, "return")}
+                >
+                  {t("return")}
+                </Button>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/features/loans/components/loan-badge.tsx
+++ b/src/features/loans/components/loan-badge.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+
+interface LoanBadgeProps {
+  type: "lent" | "borrowed";
+  personName: string | null;
+  personId: string;
+}
+
+export function LoanBadge({ type, personName, personId }: LoanBadgeProps) {
+  const t = useTranslations("loans");
+
+  const label = type === "lent"
+    ? t("lentTo", { name: personName ?? "?" })
+    : t("borrowedFrom", { name: personName ?? "?" });
+
+  return (
+    <Link
+      href={`/users/${personId}`}
+      className={[
+        "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-bold transition-colors",
+        type === "lent"
+          ? "bg-orange-500/15 text-orange-400 border border-orange-500/25 hover:bg-orange-500/25"
+          : "bg-sky-500/15 text-sky-400 border border-sky-500/25 hover:bg-sky-500/25",
+      ].join(" ")}
+    >
+      <span
+        className="material-symbols-outlined"
+        style={{ fontSize: "12px", fontVariationSettings: "'FILL' 1" }}
+      >
+        {type === "lent" ? "call_made" : "call_received"}
+      </span>
+      {label}
+    </Link>
+  );
+}

--- a/src/features/loans/components/request-loan-button.tsx
+++ b/src/features/loans/components/request-loan-button.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/features/shared/components/button";
+
+interface RequestLoanButtonProps {
+  lenderId: string;
+  bookId: string;
+}
+
+export function RequestLoanButton({ lenderId, bookId }: RequestLoanButtonProps) {
+  const t = useTranslations("loans");
+  const [state, setState] = useState<"idle" | "loading" | "done">("idle");
+
+  async function handleRequest() {
+    setState("loading");
+    try {
+      const res = await fetch("/api/loans", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type: "request", targetUserId: lenderId, bookId }),
+      });
+      if (res.ok) setState("done");
+      else setState("idle");
+    } catch {
+      setState("idle");
+    }
+  }
+
+  if (state === "done") {
+    return (
+      <span className="text-xs text-success font-semibold flex items-center gap-1">
+        <span className="material-symbols-outlined text-[14px]">check_circle</span>
+        {t("pending")}
+      </span>
+    );
+  }
+
+  return (
+    <Button
+      variant="secondary"
+      size="sm"
+      loading={state === "loading"}
+      onClick={handleRequest}
+    >
+      {state === "loading" ? t("requesting") : t("requestLoan")}
+    </Button>
+  );
+}

--- a/src/lib/loans/index.ts
+++ b/src/lib/loans/index.ts
@@ -1,0 +1,294 @@
+import "server-only";
+
+import { prisma } from "@/lib/prisma";
+import { revalidateBookCollectionPaths } from "@/lib/revalidation";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface LoanView {
+  id: string;
+  bookId: string;
+  bookTitle: string;
+  bookCoverUrl: string | null;
+  bookAuthors: string[];
+  lenderId: string;
+  lenderName: string | null;
+  lenderImage: string | null;
+  borrowerId: string;
+  borrowerName: string | null;
+  borrowerImage: string | null;
+  status: string;
+  createdAt: string;
+}
+
+const LOAN_SELECT = {
+  id: true,
+  bookId: true,
+  status: true,
+  createdAt: true,
+  lenderId: true,
+  borrowerId: true,
+  book: {
+    select: { title: true, coverUrl: true, authors: true },
+  },
+  lender: {
+    select: { id: true, name: true, image: true },
+  },
+  borrower: {
+    select: { id: true, name: true, image: true },
+  },
+} as const;
+
+function toLoanView(loan: {
+  id: string;
+  bookId: string;
+  status: string;
+  createdAt: Date;
+  lenderId: string;
+  borrowerId: string;
+  book: { title: string; coverUrl: string | null; authors: string[] };
+  lender: { id: string; name: string | null; image: string | null };
+  borrower: { id: string; name: string | null; image: string | null };
+}): LoanView {
+  return {
+    id: loan.id,
+    bookId: loan.bookId,
+    bookTitle: loan.book.title,
+    bookCoverUrl: loan.book.coverUrl,
+    bookAuthors: loan.book.authors,
+    lenderId: loan.lenderId,
+    lenderName: loan.lender.name,
+    lenderImage: loan.lender.image,
+    borrowerId: loan.borrowerId,
+    borrowerName: loan.borrower.name,
+    borrowerImage: loan.borrower.image,
+    status: loan.status,
+    createdAt: loan.createdAt.toISOString(),
+  };
+}
+
+// ── Errors ──────────────────────────────────────────────────────────────────
+
+export class LoanNotFoundError extends Error {
+  constructor() { super("Loan not found"); }
+}
+
+export class LoanForbiddenError extends Error {
+  constructor() { super("Not authorized for this loan"); }
+}
+
+export class LoanInvalidTransitionError extends Error {
+  constructor(msg: string) { super(msg); }
+}
+
+export class LoanBookNotInLibraryError extends Error {
+  constructor() { super("Book is not in the lender's library"); }
+}
+
+// ── Get loans for a user ────────────────────────────────────────────────────
+
+export async function getUserLoans(userId: string): Promise<LoanView[]> {
+  const loans = await prisma.loan.findMany({
+    where: {
+      OR: [{ lenderId: userId }, { borrowerId: userId }],
+      status: { in: ["REQUESTED", "OFFERED", "ACTIVE"] },
+    },
+    select: LOAN_SELECT,
+    orderBy: { updatedAt: "desc" },
+  });
+
+  return loans.map(toLoanView);
+}
+
+// ── Get active loan for a specific book ─────────────────────────────────────
+
+export async function getActiveLoanForBook(
+  bookId: string,
+  userId: string,
+): Promise<LoanView | null> {
+  const loan = await prisma.loan.findFirst({
+    where: {
+      bookId,
+      status: { in: ["REQUESTED", "OFFERED", "ACTIVE"] },
+      OR: [{ lenderId: userId }, { borrowerId: userId }],
+    },
+    select: LOAN_SELECT,
+  });
+
+  return loan ? toLoanView(loan) : null;
+}
+
+// ── Request to borrow ───────────────────────────────────────────────────────
+
+export async function requestLoan(
+  borrowerId: string,
+  lenderId: string,
+  bookId: string,
+): Promise<LoanView> {
+  // Verify the lender actually has this book
+  const lenderBook = await prisma.userBook.findUnique({
+    where: { userId_bookId: { userId: lenderId, bookId } },
+    select: { id: true },
+  });
+
+  if (!lenderBook) throw new LoanBookNotInLibraryError();
+
+  const loan = await prisma.loan.create({
+    data: {
+      lenderId,
+      borrowerId,
+      bookId,
+      status: "REQUESTED",
+    },
+    select: LOAN_SELECT,
+  });
+
+  return toLoanView(loan);
+}
+
+// ── Offer to lend ───────────────────────────────────────────────────────────
+
+export async function offerLoan(
+  lenderId: string,
+  borrowerId: string,
+  bookId: string,
+): Promise<LoanView> {
+  // Verify the lender actually has this book
+  const lenderBook = await prisma.userBook.findUnique({
+    where: { userId_bookId: { userId: lenderId, bookId } },
+    select: { id: true },
+  });
+
+  if (!lenderBook) throw new LoanBookNotInLibraryError();
+
+  const loan = await prisma.loan.create({
+    data: {
+      lenderId,
+      borrowerId,
+      bookId,
+      status: "OFFERED",
+    },
+    select: LOAN_SELECT,
+  });
+
+  return toLoanView(loan);
+}
+
+// ── Accept (REQUESTED → ACTIVE or OFFERED → ACTIVE) ────────────────────────
+
+export async function acceptLoan(
+  loanId: string,
+  userId: string,
+): Promise<LoanView> {
+  const loan = await prisma.loan.findUnique({
+    where: { id: loanId },
+    select: { ...LOAN_SELECT, status: true, lenderId: true, borrowerId: true },
+  });
+
+  if (!loan) throw new LoanNotFoundError();
+
+  // Only the OTHER party can accept
+  if (loan.status === "REQUESTED" && loan.lenderId !== userId) {
+    throw new LoanForbiddenError();
+  }
+  if (loan.status === "OFFERED" && loan.borrowerId !== userId) {
+    throw new LoanForbiddenError();
+  }
+  if (loan.status !== "REQUESTED" && loan.status !== "OFFERED") {
+    throw new LoanInvalidTransitionError(`Cannot accept a loan with status ${loan.status}`);
+  }
+
+  // Activate the loan
+  const updated = await prisma.loan.update({
+    where: { id: loanId },
+    data: { status: "ACTIVE" },
+    select: LOAN_SELECT,
+  });
+
+  // Create UserBook for borrower if they don't have one
+  await prisma.userBook.upsert({
+    where: { userId_bookId: { userId: loan.borrowerId, bookId: loan.bookId } },
+    create: {
+      userId: loan.borrowerId,
+      bookId: loan.bookId,
+      status: "READING",
+    },
+    update: {},
+  });
+
+  revalidateBookCollectionPaths(loan.bookId);
+  return toLoanView(updated);
+}
+
+// ── Decline (REQUESTED → DECLINED or OFFERED → DECLINED) ───────────────────
+
+export async function declineLoan(
+  loanId: string,
+  userId: string,
+): Promise<LoanView> {
+  const loan = await prisma.loan.findUnique({
+    where: { id: loanId },
+    select: LOAN_SELECT,
+  });
+
+  if (!loan) throw new LoanNotFoundError();
+
+  // The other party declines, or the initiator cancels
+  if (loan.lenderId !== userId && loan.borrowerId !== userId) {
+    throw new LoanForbiddenError();
+  }
+  if (loan.status !== "REQUESTED" && loan.status !== "OFFERED") {
+    throw new LoanInvalidTransitionError(`Cannot decline a loan with status ${loan.status}`);
+  }
+
+  const updated = await prisma.loan.update({
+    where: { id: loanId },
+    data: { status: "DECLINED" },
+    select: LOAN_SELECT,
+  });
+
+  return toLoanView(updated);
+}
+
+// ── Return (ACTIVE → RETURNED) ─────────────────────────────────────────────
+
+export async function returnLoan(
+  loanId: string,
+  userId: string,
+): Promise<LoanView> {
+  const loan = await prisma.loan.findUnique({
+    where: { id: loanId },
+    select: LOAN_SELECT,
+  });
+
+  if (!loan) throw new LoanNotFoundError();
+
+  // Either party can mark as returned
+  if (loan.lenderId !== userId && loan.borrowerId !== userId) {
+    throw new LoanForbiddenError();
+  }
+  if (loan.status !== "ACTIVE") {
+    throw new LoanInvalidTransitionError(`Cannot return a loan with status ${loan.status}`);
+  }
+
+  const updated = await prisma.loan.update({
+    where: { id: loanId },
+    data: { status: "RETURNED" },
+    select: LOAN_SELECT,
+  });
+
+  // If borrower didn't finish (status != READ), remove their UserBook
+  const borrowerBook = await prisma.userBook.findUnique({
+    where: { userId_bookId: { userId: loan.borrowerId, bookId: loan.bookId } },
+    select: { id: true, status: true },
+  });
+
+  if (borrowerBook && borrowerBook.status !== "READ") {
+    await prisma.userBook.delete({
+      where: { id: borrowerBook.id },
+    });
+  }
+
+  revalidateBookCollectionPaths(loan.bookId);
+  return toLoanView(updated);
+}


### PR DESCRIPTION
## Summary
- New Loan model with LoanStatus enum (REQUESTED, OFFERED, ACTIVE, RETURNED, DECLINED)
- Full API: request, offer, accept, decline, return with business logic
- Dashboard loans section with inline actions
- "Request to borrow" button on discovered book detail
- Return logic: keep UserBook if READ, delete if unfinished