### PR TITLE
feat(groups): shared library catalog with genre sections and personal read filter

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -262,7 +262,21 @@
     "notFound": "Group not found.",
     "forbidden": "You don't have access to this group.",
     "you": "(you)",
-    "noMembers": "No members yet."
+    "noMembers": "No members yet.",
+    "catalog": "Catalog",
+    "catalogDescription": "All books from group members.",
+    "viewByGenre": "By genre",
+    "viewAll": "See all",
+    "filterAll": "All",
+    "filterRead": "Read",
+    "filterUnread": "Unread",
+    "noGenre": "Uncategorized",
+    "readCheck": "Read by you",
+    "emptyGenre": "No books in this category.",
+    "emptyCatalog": "The shared library is empty.",
+    "emptyCatalogDescription": "Members need to add books to their library first.",
+    "emptyFiltered": "No books match this filter.",
+    "bookCount": "{count, plural, one {# book} other {# books}}"
   },
   "lists": {
     "title": "My Lists",

--- a/messages/es.json
+++ b/messages/es.json
@@ -262,7 +262,21 @@
     "notFound": "Grupo no encontrado.",
     "forbidden": "No tienes acceso a este grupo.",
     "you": "(tú)",
-    "noMembers": "Aún no hay miembros."
+    "noMembers": "Aún no hay miembros.",
+    "catalog": "Catálogo",
+    "catalogDescription": "Todos los libros de los miembros del grupo.",
+    "viewByGenre": "Por género",
+    "viewAll": "Ver todos",
+    "filterAll": "Todos",
+    "filterRead": "Leídos",
+    "filterUnread": "No leídos",
+    "noGenre": "Sin género",
+    "readCheck": "Leído por ti",
+    "emptyGenre": "No hay libros en esta categoría.",
+    "emptyCatalog": "La biblioteca compartida está vacía.",
+    "emptyCatalogDescription": "Los miembros deben añadir libros a su biblioteca primero.",
+    "emptyFiltered": "No hay libros con este filtro.",
+    "bookCount": "{count, plural, one {# libro} other {# libros}}"
   },
   "lists": {
     "title": "Mis Listas",

--- a/src/app/api/groups/[id]/books/route.ts
+++ b/src/app/api/groups/[id]/books/route.ts
@@ -8,9 +8,6 @@ type RouteContext = {
   params: Promise<{ id: string }>;
 };
 
-const DEFAULT_LIMIT = 20;
-const MAX_LIMIT = 50;
-
 export async function GET(
   request: NextRequest,
   { params }: RouteContext
@@ -29,14 +26,8 @@ export async function GET(
       return Response.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    // Pagination params
-    const searchParams = request.nextUrl.searchParams;
-    const cursor = searchParams.get("cursor");
-    const limitParam = searchParams.get("limit");
-    const limit = Math.min(
-      parseInt(limitParam ?? String(DEFAULT_LIMIT), 10) || DEFAULT_LIMIT,
-      MAX_LIMIT
-    );
+    // Optional read filter: "all" (default) | "read" | "unread"
+    const readFilter = request.nextUrl.searchParams.get("readFilter") ?? "all";
 
     // Get all ACCEPTED member userIds in this group
     const acceptedMembers = await prisma.groupMember.findMany({
@@ -44,75 +35,56 @@ export async function GET(
       select: { userId: true },
     });
 
-    const memberUserIds = acceptedMembers.map((m) => m.userId);
+    const memberUserIds = acceptedMembers.map((m: { userId: string }) => m.userId);
 
-    // Handle empty group edge case (EC6)
     if (memberUserIds.length === 0) {
-      return Response.json({ books: [], nextCursor: null });
+      return Response.json({ books: [] });
     }
 
-    // Fetch all UserBooks from group members (excluding notes — NF5)
-    // We query Books with pagination, then attach member ratings
+    // Fetch ALL unique books owned by any group member, with genres
     const books = await prisma.book.findMany({
       where: {
+        userBooks: { some: { userId: { in: memberUserIds } } },
+      },
+      select: {
+        id: true,
+        title: true,
+        authors: true,
+        coverUrl: true,
+        genres: true,
         userBooks: {
-          some: { userId: { in: memberUserIds } },
+          where: { userId },
+          select: { status: true },
+          take: 1,
         },
       },
-      include: {
-        userBooks: {
-          where: { userId: { in: memberUserIds } },
-          select: {
-            userId: true,
-            status: true,
-            rating: true,
-            // notes intentionally excluded (owner-only per NF5)
-            user: { select: { id: true, name: true } },
-          },
-        },
-      },
-      orderBy: { createdAt: "desc" },
-      take: limit + 1,
-      ...(cursor
-        ? {
-            cursor: { id: cursor },
-            skip: 1,
-          }
-        : {}),
+      orderBy: { title: "asc" },
     });
 
-    let nextCursor: string | null = null;
-    if (books.length > limit) {
-      const nextItem = books.pop();
-      nextCursor = nextItem?.id ?? null;
-    }
+    // Map to response shape: flat book + currentUserStatus
+    const mapped = books
+      .map((b) => {
+        const myEntry = b.userBooks[0] ?? null;
+        const currentUserStatus = myEntry?.status ?? null;
+        const isRead = currentUserStatus === "READ";
 
-    const result = books.map((book) => ({
-      book: {
-        id: book.id,
-        title: book.title,
-        subtitle: book.subtitle,
-        authors: book.authors,
-        description: book.description,
-        coverUrl: book.coverUrl,
-        publisher: book.publisher,
-        publishedDate: book.publishedDate,
-        pageCount: book.pageCount,
-        isbn10: book.isbn10,
-        isbn13: book.isbn13,
-        genres: book.genres,
-        createdAt: book.createdAt,
-        updatedAt: book.updatedAt,
-      },
-      memberRatings: book.userBooks.map((ub) => ({
-        userId: ub.userId,
-        userName: ub.user.name,
-        rating: ub.rating,
-        status: ub.status,
-      })),
-    }));
+        return {
+          id: b.id,
+          title: b.title,
+          authors: b.authors,
+          coverUrl: b.coverUrl,
+          genres: b.genres,
+          currentUserStatus,
+          isRead,
+        };
+      })
+      .filter((b) => {
+        if (readFilter === "read") return b.isRead;
+        if (readFilter === "unread") return !b.isRead;
+        return true;
+      });
 
-    return Response.json({ books: result, nextCursor });
+    return Response.json({ books: mapped });
   } catch (error) {
     if (error instanceof UnauthorizedError) {
       return Response.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/groups/[id]/page.tsx
+++ b/src/app/groups/[id]/page.tsx
@@ -1,11 +1,9 @@
-import { redirect, notFound } from 'next/navigation';
-import Link from 'next/link';
-import { getTranslations } from 'next-intl/server';
-import { prisma } from '@/lib/prisma';
-import { auth } from '@/lib/auth';
-import { GroupBookFeed } from '@/features/groups/components/group-book-feed';
-
-const DEFAULT_LIMIT = 20;
+import { redirect, notFound } from "next/navigation";
+import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+import { prisma } from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+import { GroupLibraryCatalog } from "@/features/groups/components/group-library-catalog";
 
 interface GroupFeedPageProps {
   params: Promise<{ id: string }>;
@@ -14,24 +12,20 @@ interface GroupFeedPageProps {
 export default async function GroupFeedPage({ params }: GroupFeedPageProps) {
   const session = await auth();
   if (!session?.user?.id) {
-    redirect('/login');
+    redirect("/login");
   }
   const userId = session.user.id;
 
   const { id: groupId } = await params;
-  const t = await getTranslations('groups');
+  const t = await getTranslations("groups");
 
   // Verify group exists and user is an ACCEPTED member
   const membership = await prisma.groupMember.findUnique({
     where: { groupId_userId: { groupId, userId } },
-    select: { status: true, role: true },
+    select: { status: true },
   });
 
-  if (!membership) {
-    notFound();
-  }
-
-  if (membership.status !== 'ACCEPTED') {
+  if (!membership || membership.status !== "ACCEPTED") {
     notFound();
   }
 
@@ -40,7 +34,7 @@ export default async function GroupFeedPage({ params }: GroupFeedPageProps) {
     select: {
       id: true,
       name: true,
-      _count: { select: { members: { where: { status: 'ACCEPTED' } } } },
+      _count: { select: { members: { where: { status: "ACCEPTED" } } } },
     },
   });
 
@@ -48,111 +42,91 @@ export default async function GroupFeedPage({ params }: GroupFeedPageProps) {
     notFound();
   }
 
-  // Fetch initial book feed
-  const acceptedMemberIds = await prisma.groupMember
-    .findMany({ where: { groupId, status: 'ACCEPTED' }, select: { userId: true } })
-    .then((rows) => rows.map((r) => r.userId));
+  // Fetch all ACCEPTED member IDs
+  const acceptedMembers = await prisma.groupMember.findMany({
+    where: { groupId, status: "ACCEPTED" },
+    select: { userId: true },
+  });
 
-  let initialBooks: {
-    book: {
-      id: string;
-      title: string;
-      authors: string[];
-      coverUrl: string | null;
-      publisher: string | null;
-      publishedDate: string | null;
-    };
-    memberRatings: {
-      userId: string;
-      userName: string | null;
-      rating: number | null;
-      status: string;
-    }[];
-  }[] = [];
-  let initialNextCursor: string | null = null;
+  const memberUserIds = acceptedMembers.map((m) => m.userId);
 
-  if (acceptedMemberIds.length > 0) {
-    const books = await prisma.book.findMany({
-      where: { userBooks: { some: { userId: { in: acceptedMemberIds } } } },
-      include: {
-        userBooks: {
-          where: { userId: { in: acceptedMemberIds } },
-          select: {
-            userId: true,
-            status: true,
-            rating: true,
-            user: { select: { id: true, name: true } },
+  // Fetch ALL unique books from group members with genres + current user status
+  const books =
+    memberUserIds.length > 0
+      ? await prisma.book.findMany({
+          where: {
+            userBooks: { some: { userId: { in: memberUserIds } } },
           },
-        },
-      },
-      orderBy: { createdAt: 'desc' },
-      take: DEFAULT_LIMIT + 1,
-    });
+          select: {
+            id: true,
+            title: true,
+            authors: true,
+            coverUrl: true,
+            genres: true,
+            userBooks: {
+              where: { userId },
+              select: { status: true },
+              take: 1,
+            },
+          },
+          orderBy: { title: "asc" },
+        })
+      : [];
 
-    if (books.length > DEFAULT_LIMIT) {
-      const nextItem = books.pop();
-      initialNextCursor = nextItem?.id ?? null;
-    }
-
-    initialBooks = books.map((b) => ({
-      book: {
-        id: b.id,
-        title: b.title,
-        authors: b.authors,
-        coverUrl: b.coverUrl,
-        publisher: b.publisher,
-        publishedDate: b.publishedDate,
-      },
-      memberRatings: b.userBooks.map((ub) => ({
-        userId: ub.userId,
-        userName: ub.user.name,
-        rating: ub.rating,
-        status: ub.status,
-      })),
-    }));
-  }
+  const catalogBooks = books.map((b) => {
+    const myEntry = b.userBooks[0] ?? null;
+    return {
+      id: b.id,
+      title: b.title,
+      authors: b.authors,
+      coverUrl: b.coverUrl,
+      genres: b.genres,
+      currentUserStatus: myEntry?.status ?? null,
+      isRead: myEntry?.status === "READ",
+    };
+  });
 
   return (
     <div className="grid gap-6 px-12 md:px-20 pt-8 pb-24">
       {/* Page header */}
       <div
         className="rounded-[var(--radius-xl)] border border-line bg-gradient-to-b from-[rgba(19,27,41,0.88)] to-[rgba(8,12,20,0.88)] p-6 flex items-start justify-between gap-4"
-        style={{ backdropFilter: 'blur(16px)' }}
+        style={{ backdropFilter: "blur(16px)" }}
       >
         <div className="grid gap-1">
           <p className="text-xs font-bold uppercase tracking-widest text-muted">
-            <Link href="/groups" className="hover:text-primary transition-colors">
-              {t('heading')}
+            <Link
+              href="/groups"
+              className="hover:text-primary transition-colors"
+            >
+              {t("heading")}
             </Link>
-            {' / '}
+            {" / "}
             {group.name}
           </p>
           <h1
             className="text-3xl font-bold text-text"
-            style={{ fontFamily: 'var(--font-headline)' }}
+            style={{ fontFamily: "var(--font-headline)" }}
           >
             {group.name}
           </h1>
-          <p className="text-sm text-muted">{t('memberCount', { count: group._count.members })}</p>
+          <p className="text-sm text-muted">
+            {t("memberCount", { count: group._count.members })}
+            {" · "}
+            {t("bookCount", { count: catalogBooks.length })}
+          </p>
         </div>
         <Link
           href={`/groups/${groupId}/members`}
           className="shrink-0 inline-flex items-center gap-1.5 px-4 py-2 rounded-full bg-white/10 text-text border border-line text-sm font-medium hover:-translate-y-px transition-transform"
         >
           <span className="material-symbols-outlined text-[16px]">group</span>
-          {t('members')}
+          {t("members")}
         </Link>
       </div>
 
-      {/* Book feed */}
-      <section className="grid gap-4">
-        <h2 className="text-lg font-semibold text-on-surface">{t('feed')}</h2>
-        <GroupBookFeed
-          groupId={groupId}
-          initialBooks={initialBooks}
-          initialNextCursor={initialNextCursor}
-        />
-      </section>
+      {/* Shared library catalog */}
+      <GroupLibraryCatalog books={catalogBooks} />
     </div>
   );
 }

--- a/src/features/groups/components/group-book-card.tsx
+++ b/src/features/groups/components/group-book-card.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { BookCover } from "@/features/books/components/book-cover";
+import { cn } from "@/lib/cn";
+
+interface GroupBookCardProps {
+  book: {
+    id: string;
+    title: string;
+    authors: string[];
+    coverUrl: string | null;
+    isRead: boolean;
+  };
+  index?: number;
+}
+
+export function GroupBookCard({ book, index = 0 }: GroupBookCardProps) {
+  const t = useTranslations();
+  const authorLine =
+    book.authors.length > 0
+      ? book.authors.join(", ")
+      : t("common.unknownAuthor");
+
+  return (
+    <Link
+      href={`/books/${book.id}`}
+      className={cn(
+        "group relative block rounded-[var(--radius-md)] border border-line bg-surface overflow-hidden",
+        "transition-all duration-250 ease-out",
+        "hover:scale-105 hover:z-10 hover:shadow-lg hover:border-white/28",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent",
+      )}
+      style={{
+        animationName: "fade-slide-up",
+        animationDuration: "350ms",
+        animationTimingFunction: "ease",
+        animationFillMode: "both",
+        animationDelay: `${index * 60}ms`,
+        width: "118px",
+        minWidth: "118px",
+        scrollSnapAlign: "start",
+      }}
+      aria-label={`${book.title} — ${authorLine}`}
+    >
+      {/* Cover */}
+      <BookCover
+        coverUrl={book.coverUrl}
+        title={book.title}
+        tone="cool"
+        className="w-full h-[176px] min-h-[176px]"
+        sizes="118px"
+      />
+
+      {/* Read check badge */}
+      {book.isRead && (
+        <div
+          className="absolute top-1.5 right-1.5 flex items-center justify-center w-6 h-6 rounded-full bg-accent/90 text-white shadow-md"
+          aria-label={t("groups.readCheck")}
+        >
+          <span
+            className="material-symbols-outlined"
+            style={{ fontSize: "14px" }}
+          >
+            check
+          </span>
+        </div>
+      )}
+
+      {/* Info */}
+      <div className="p-2 grid gap-1">
+        <h3
+          className="text-[0.78rem] font-bold text-text leading-tight line-clamp-2"
+          style={{ fontFamily: "var(--font-headline)" }}
+        >
+          {book.title}
+        </h3>
+        <p className="text-[0.7rem] text-muted truncate">{authorLine}</p>
+      </div>
+    </Link>
+  );
+}

--- a/src/features/groups/components/group-library-catalog.tsx
+++ b/src/features/groups/components/group-library-catalog.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { useTranslations } from "next-intl";
+import { BookRailSection } from "@/features/shared/ui/book-rail-section";
+import { EmptyState } from "@/features/shared/components/empty-state";
+import { GroupBookCard } from "./group-book-card";
+import { cn } from "@/lib/cn";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface CatalogBook {
+  id: string;
+  title: string;
+  authors: string[];
+  coverUrl: string | null;
+  genres: string[];
+  currentUserStatus: string | null;
+  isRead: boolean;
+}
+
+type ViewMode = "genre" | "all";
+type ReadFilter = "all" | "read" | "unread";
+
+interface GroupLibraryCatalogProps {
+  books: CatalogBook[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function groupByGenre(books: CatalogBook[], noGenreLabel: string) {
+  const genreMap = new Map<string, CatalogBook[]>();
+
+  for (const book of books) {
+    const genres = book.genres.length > 0 ? book.genres : [noGenreLabel];
+    for (const genre of genres) {
+      const list = genreMap.get(genre) ?? [];
+      list.push(book);
+      genreMap.set(genre, list);
+    }
+  }
+
+  // Sort genres alphabetically, but push "no genre" to the end
+  return Array.from(genreMap.entries()).sort(([a], [b]) => {
+    if (a === noGenreLabel) return 1;
+    if (b === noGenreLabel) return -1;
+    return a.localeCompare(b);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Filter pill component
+// ---------------------------------------------------------------------------
+
+function FilterPill({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "inline-flex items-center px-4 py-2 rounded-full text-sm font-bold transition-all duration-200",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent",
+        active
+          ? "bg-gradient-to-br from-accent to-accent-strong text-white border border-transparent"
+          : "bg-white/6 text-muted border border-white/12 hover:text-text hover:-translate-y-px",
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function GroupLibraryCatalog({ books }: GroupLibraryCatalogProps) {
+  const t = useTranslations("groups");
+  const [viewMode, setViewMode] = useState<ViewMode>("genre");
+  const [readFilter, setReadFilter] = useState<ReadFilter>("all");
+
+  // Apply read filter
+  const filteredBooks = useMemo(() => {
+    if (readFilter === "read") return books.filter((b) => b.isRead);
+    if (readFilter === "unread") return books.filter((b) => !b.isRead);
+    return books;
+  }, [books, readFilter]);
+
+  // Group by genre for the genre view
+  const genreSections = useMemo(
+    () => groupByGenre(filteredBooks, t("noGenre")),
+    [filteredBooks, t],
+  );
+
+  // Empty states
+  if (books.length === 0) {
+    return (
+      <EmptyState
+        title={t("emptyCatalog")}
+        description={t("emptyCatalogDescription")}
+      />
+    );
+  }
+
+  if (filteredBooks.length === 0) {
+    return (
+      <>
+        <CatalogFilters
+          viewMode={viewMode}
+          readFilter={readFilter}
+          onViewModeChange={setViewMode}
+          onReadFilterChange={setReadFilter}
+        />
+        <EmptyState title={t("emptyFiltered")} />
+      </>
+    );
+  }
+
+  return (
+    <div className="grid gap-6">
+      <CatalogFilters
+        viewMode={viewMode}
+        readFilter={readFilter}
+        onViewModeChange={setViewMode}
+        onReadFilterChange={setReadFilter}
+      />
+
+      {viewMode === "genre" ? (
+        <div className="grid gap-8">
+          {genreSections.map(([genre, genreBooks]) => (
+            <BookRailSection
+              key={genre}
+              title={genre}
+              count={genreBooks.length}
+            >
+              {genreBooks.map((book, i) => (
+                <GroupBookCard key={book.id} book={book} index={i} />
+              ))}
+            </BookRailSection>
+          ))}
+        </div>
+      ) : (
+        <div className="grid grid-cols-[repeat(auto-fill,118px)] gap-4 justify-center">
+          {filteredBooks.map((book, i) => (
+            <GroupBookCard key={book.id} book={book} index={i} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Filters bar
+// ---------------------------------------------------------------------------
+
+function CatalogFilters({
+  viewMode,
+  readFilter,
+  onViewModeChange,
+  onReadFilterChange,
+}: {
+  viewMode: ViewMode;
+  readFilter: ReadFilter;
+  onViewModeChange: (v: ViewMode) => void;
+  onReadFilterChange: (f: ReadFilter) => void;
+}) {
+  const t = useTranslations("groups");
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      {/* View mode toggle */}
+      <div className="flex gap-1.5">
+        <FilterPill
+          label={t("viewByGenre")}
+          active={viewMode === "genre"}
+          onClick={() => onViewModeChange("genre")}
+        />
+        <FilterPill
+          label={t("viewAll")}
+          active={viewMode === "all"}
+          onClick={() => onViewModeChange("all")}
+        />
+      </div>
+
+      {/* Separator */}
+      <div className="w-px h-6 bg-line" aria-hidden="true" />
+
+      {/* Read filter */}
+      <div className="flex gap-1.5">
+        <FilterPill
+          label={t("filterAll")}
+          active={readFilter === "all"}
+          onClick={() => onReadFilterChange("all")}
+        />
+        <FilterPill
+          label={t("filterRead")}
+          active={readFilter === "read"}
+          onClick={() => onReadFilterChange("read")}
+        />
+        <FilterPill
+          label={t("filterUnread")}
+          active={readFilter === "unread"}
+          onClick={() => onReadFilterChange("unread")}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Replaces the flat chronological book feed in group detail pages with a genre-based shared library catalog. The group page now feels like browsing a unified library of all members' books.

### What changed

**New UX:**
- Books from all group members displayed as a single shared catalog
- Organized by **genre carousels** (Fantasy, History, Drama, etc.)
- **View toggle**: "By genre" (default, carousels) vs "See all" (flat grid)
- **Personal read filter**: All / Read by me / Unread — filters based on current user only
- Books you've read show a **✓ check badge** on the cover
- No member-level info in the list — for that, visit book detail or member profile

**New files:**
- `src/features/groups/components/group-book-card.tsx` — Simple card with cover, title, authors, and read check badge
- `src/features/groups/components/group-library-catalog.tsx` — Main catalog with genre grouping, view toggle, and read filter

**Modified files:**
- `src/app/groups/[id]/page.tsx` — Uses new catalog instead of old feed
- `src/app/api/groups/[id]/books/route.ts` — Returns genres + current user's status for each book
- `messages/es.json` + `messages/en.json` — 15 new i18n keys

### Verification
- `npm run lint:strict` → 0 errors
- `npx tsc --noEmit` → clean
- `npm test` → 232/232 passing

Closes #11