### PR TITLE
feat(library): bulk status change — select multiple books and move them at once

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -113,7 +113,14 @@
       "REREADING": "You're not rereading any books.",
       "READ": "You haven't marked any books as read yet.",
       "ON_HOLD": "No books on hold."
-    }
+    },
+    "select": "Select",
+    "cancelSelection": "Cancel",
+    "selectedCount": "{count, plural, one {# selected} other {# selected}}",
+    "moveTo": "Move to",
+    "batchSuccess": "{count, plural, one {# book moved} other {# books moved}}",
+    "selectAll": "All",
+    "deselectAll": "None"
   },
   "search": {
     "heading": "Explore books",

--- a/messages/es.json
+++ b/messages/es.json
@@ -113,7 +113,14 @@
       "REREADING": "No estás releyendo ningún libro.",
       "READ": "Aún no has marcado ningún libro como leído.",
       "ON_HOLD": "No tienes libros en pausa."
-    }
+    },
+    "select": "Seleccionar",
+    "cancelSelection": "Cancelar",
+    "selectedCount": "{count, plural, one {# seleccionado} other {# seleccionados}}",
+    "moveTo": "Mover a",
+    "batchSuccess": "{count, plural, one {# libro movido} other {# libros movidos}}",
+    "selectAll": "Todos",
+    "deselectAll": "Ninguno"
   },
   "search": {
     "heading": "Explorar libros",

--- a/src/app/api/books/batch/route.ts
+++ b/src/app/api/books/batch/route.ts
@@ -1,0 +1,62 @@
+import "server-only";
+
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, UnauthorizedError } from "@/lib/auth/require-auth";
+import { BOOK_STATUS_VALUES, type BookStatus } from "@/lib/types/book";
+import { revalidateBookCollectionPaths } from "@/lib/revalidation";
+
+const batchUpdateSchema = z.object({
+  bookIds: z.array(z.string().min(1)).min(1).max(100),
+  status: z.enum(BOOK_STATUS_VALUES as [BookStatus, ...BookStatus[]]),
+});
+
+/**
+ * PATCH /api/books/batch
+ *
+ * Updates the status of multiple books at once for the authenticated user.
+ * Only updates UserBook rows that belong to the caller.
+ */
+export async function PATCH(request: Request): Promise<Response> {
+  try {
+    const { userId } = await requireAuth();
+    const body = await request.json();
+    const result = batchUpdateSchema.safeParse(body);
+
+    if (!result.success) {
+      return Response.json(
+        { error: "Invalid request", details: result.error.flatten() },
+        { status: 400 },
+      );
+    }
+
+    const { bookIds, status } = result.data;
+
+    const updated = await prisma.userBook.updateMany({
+      where: {
+        userId,
+        bookId: { in: bookIds },
+      },
+      data: {
+        status,
+        ...(status === "READ" ? { finishedAt: new Date() } : {}),
+      },
+    });
+
+    // Revalidate library paths
+    for (const bookId of bookIds) {
+      revalidateBookCollectionPaths(bookId);
+    }
+
+    return Response.json({
+      updated: updated.count,
+      status,
+    });
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    console.error("[PATCH /api/books/batch]", error);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -1,12 +1,9 @@
 import { redirect } from "next/navigation";
-import { getTranslations } from 'next-intl/server';
 import { type BookStatus, BOOK_STATUS_VALUES } from "@/lib/types/book";
 import { prisma } from "@/lib/prisma";
 import { getAuthenticatedUserIdOrNull } from "@/lib/auth/require-auth";
-import { LibraryBookCard } from "@/features/books/components/library-book-card";
-import { StatusTabs, type StatusCounts, type StatusTabValue } from "@/features/books/components/status-tabs";
-import { EmptyState } from "@/features/shared/components/empty-state";
-import { BookRailSection } from "@/features/shared/ui/book-rail-section";
+import type { StatusCounts, StatusTabValue } from "@/features/books/components/status-tabs";
+import { LibraryView } from "@/features/books/components/library-view";
 
 interface LibraryBookRow {
   id: string;
@@ -27,8 +24,6 @@ interface StatusCountRow {
   status: BookStatus;
   _count: { id: number };
 }
-
-const STATUS_ORDERED: BookStatus[] = ["READING", "REREADING", "TO_READ", "READ", "ON_HOLD", "WISHLIST"];
 
 type SearchParams = Record<string, string | string[] | undefined>;
 
@@ -67,8 +62,6 @@ export default async function LibraryPage({ searchParams }: LibraryPageProps) {
   const activeStatus = resolveActiveStatus(statusParam);
   const tabSearchParams = toStringRecord(params);
 
-  const t = await getTranslations();
-
   const [userBooks, groupedCounts]: [LibraryBookRow[], StatusCountRow[]] = await Promise.all([
     prisma.userBook.findMany({
       where: activeStatus !== "all" ? { userId, status: activeStatus } : { userId },
@@ -101,7 +94,6 @@ export default async function LibraryPage({ searchParams }: LibraryPageProps) {
     { WISHLIST: 0, TO_READ: 0, READING: 0, REREADING: 0, READ: 0, ON_HOLD: 0 },
   );
 
-  // Flatten UserBook + Book into the shape LibraryBookCard expects
   const books = userBooks.map((ub) => ({
     id: ub.book.id,
     title: ub.book.title,
@@ -114,77 +106,14 @@ export default async function LibraryPage({ searchParams }: LibraryPageProps) {
     publishedDate: ub.book.publishedDate,
   }));
 
-  const isEmpty = books.length === 0;
-
-  function getFilterTitle(status: BookStatus): string {
-    return `No ${t(`book.status.${status}`)} books`;
-  }
-
   return (
     <div className="grid gap-6 px-12 md:px-20 pt-8 pb-24">
-      <div
-        className="rounded-[var(--radius-xl)] border border-line bg-gradient-to-b from-[rgba(19,27,41,0.88)] to-[rgba(8,12,20,0.88)] p-6 grid gap-4"
-        style={{ backdropFilter: "blur(16px)" }}
-      >
-        <div className="grid gap-1">
-          <p className="text-xs font-bold uppercase tracking-widest text-muted">Library</p>
-          <h1 className="text-3xl font-bold text-text" style={{ fontFamily: "var(--font-headline)" }}>
-            {t('library.heading')}
-          </h1>
-          <p className="text-sm text-muted leading-relaxed max-w-lg">
-            {t('library.description')}
-          </p>
-        </div>
-
-        <StatusTabs activeStatus={activeStatus} counts={counts} searchParams={tabSearchParams} />
-      </div>
-
-      {isEmpty ? (
-        <EmptyState
-          title={activeStatus === "all" ? t('library.emptyAll') : getFilterTitle(activeStatus)}
-          description={
-            activeStatus === "all"
-              ? t('library.searchPlaceholder')
-              : t('library.tryAnotherStatus')
-          }
-        />
-      ) : activeStatus !== "all" ? (
-        <BookRailSection
-          title={t(`library.statusEyebrow.${activeStatus}`)}
-          eyebrow={t(`book.status.${activeStatus}`)}
-          count={books.length}
-          emptyCopy={t('library.emptyFilter')}
-        >
-          {books.map((book) => (
-            <div key={book.id} className="shrink-0 w-[clamp(260px,32vw,340px)]" style={{ scrollSnapAlign: "start" }}>
-              <LibraryBookCard book={book} />
-            </div>
-          ))}
-        </BookRailSection>
-      ) : (
-        <div className="grid gap-4">
-          {STATUS_ORDERED.map((status) => {
-            const statusBooks = books.filter((book) => book.status === status);
-
-            return (
-              <BookRailSection
-                key={status}
-                title={t(`library.statusEyebrow.${status}`)}
-                eyebrow={t(`book.status.${status}`)}
-                count={statusBooks.length}
-                emptyTitle={getFilterTitle(status)}
-                emptyCopy={t(`library.statusEmpty.${status}`)}
-              >
-                {statusBooks.map((book) => (
-                  <div key={book.id} className="shrink-0 w-[clamp(260px,32vw,340px)]" style={{ scrollSnapAlign: "start" }}>
-                    <LibraryBookCard book={book} />
-                  </div>
-                ))}
-              </BookRailSection>
-            );
-          })}
-        </div>
-      )}
+      <LibraryView
+        books={books}
+        counts={counts}
+        activeStatus={activeStatus}
+        searchParams={tabSearchParams}
+      />
     </div>
   );
 }

--- a/src/features/books/components/library-view.tsx
+++ b/src/features/books/components/library-view.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import type { BookStatus } from "@/lib/types/book";
+import { StatusTabs, type StatusCounts, type StatusTabValue } from "./status-tabs";
+import { LibraryBookCard, type LibraryBook } from "./library-book-card";
+import { SelectionToolbar } from "./selection-toolbar";
+import { BookRailSection } from "@/features/shared/ui/book-rail-section";
+import { EmptyState } from "@/features/shared/components/empty-state";
+import { cn } from "@/lib/cn";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface LibraryViewProps {
+  books: LibraryBook[];
+  counts: StatusCounts;
+  activeStatus: StatusTabValue;
+  searchParams: Record<string, string>;
+}
+
+const STATUS_ORDERED: BookStatus[] = [
+  "READING", "REREADING", "TO_READ", "READ", "ON_HOLD", "WISHLIST",
+];
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function LibraryView({
+  books,
+  counts,
+  activeStatus,
+  searchParams,
+}: LibraryViewProps) {
+  const router = useRouter();
+  const t = useTranslations();
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  // Toggle selection of a single book
+  const toggleSelect = useCallback((bookId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(bookId)) {
+        next.delete(bookId);
+      } else {
+        next.add(bookId);
+      }
+      return next;
+    });
+  }, []);
+
+  // Exit selection mode
+  function exitSelectionMode() {
+    setSelectionMode(false);
+    setSelectedIds(new Set());
+  }
+
+  // Batch status change via API
+  async function handleBatchStatusChange(status: BookStatus) {
+    if (selectedIds.size === 0) return;
+
+    const res = await fetch("/api/books/batch", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        bookIds: Array.from(selectedIds),
+        status,
+      }),
+    });
+
+    if (res.ok) {
+      exitSelectionMode();
+      router.refresh();
+    }
+  }
+
+  // Select / deselect all visible books
+  function selectAll() {
+    setSelectedIds(new Set(books.map((b) => b.id)));
+  }
+
+  const isEmpty = books.length === 0;
+
+  function getFilterTitle(status: BookStatus): string {
+    return `No ${t(`book.status.${status}`)} books`;
+  }
+
+  return (
+    <div className="grid gap-6">
+      {/* Header card */}
+      <div
+        className="rounded-[var(--radius-xl)] border border-line bg-gradient-to-b from-[rgba(19,27,41,0.88)] to-[rgba(8,12,20,0.88)] p-6 grid gap-4"
+        style={{ backdropFilter: "blur(16px)" }}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div className="grid gap-1">
+            <p className="text-xs font-bold uppercase tracking-widest text-muted">Library</p>
+            <h1
+              className="text-3xl font-bold text-text"
+              style={{ fontFamily: "var(--font-headline)" }}
+            >
+              {t("library.heading")}
+            </h1>
+            <p className="text-sm text-muted leading-relaxed max-w-lg">
+              {t("library.description")}
+            </p>
+          </div>
+
+          {/* Selection toggle button */}
+          {!isEmpty && (
+            <button
+              type="button"
+              onClick={selectionMode ? exitSelectionMode : () => setSelectionMode(true)}
+              className={cn(
+                "shrink-0 inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-bold transition-all duration-200",
+                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent",
+                selectionMode
+                  ? "bg-accent/15 text-accent border border-accent/30"
+                  : "bg-white/10 text-text border border-line hover:-translate-y-px",
+              )}
+            >
+              <span className="material-symbols-outlined text-[16px]">
+                {selectionMode ? "close" : "checklist"}
+              </span>
+              {selectionMode ? t("library.cancelSelection") : t("library.select")}
+            </button>
+          )}
+        </div>
+
+        {/* Select all / deselect all — only in selection mode */}
+        {selectionMode && (
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={selectAll}
+              className="text-xs text-accent font-bold hover:underline"
+            >
+              {t("library.selectAll")}
+            </button>
+            <button
+              type="button"
+              onClick={() => setSelectedIds(new Set())}
+              className="text-xs text-muted font-bold hover:underline"
+            >
+              {t("library.deselectAll")}
+            </button>
+          </div>
+        )}
+
+        <StatusTabs activeStatus={activeStatus} counts={counts} searchParams={searchParams} />
+      </div>
+
+      {/* Book content */}
+      {isEmpty ? (
+        <EmptyState
+          title={
+            activeStatus === "all"
+              ? t("library.emptyAll")
+              : getFilterTitle(activeStatus as BookStatus)
+          }
+          description={
+            activeStatus === "all"
+              ? t("library.searchPlaceholder")
+              : t("library.tryAnotherStatus")
+          }
+        />
+      ) : activeStatus !== "all" ? (
+        <BookRailSection
+          title={t(`library.statusEyebrow.${activeStatus}`)}
+          eyebrow={t(`book.status.${activeStatus}`)}
+          count={books.length}
+          emptyCopy={t("library.emptyFilter")}
+        >
+          {books.map((book) => (
+            <div
+              key={book.id}
+              className="shrink-0 w-[clamp(260px,32vw,340px)]"
+              style={{ scrollSnapAlign: "start" }}
+            >
+              <BookCardWithSelection
+                book={book}
+                selectionMode={selectionMode}
+                selected={selectedIds.has(book.id)}
+                onToggle={toggleSelect}
+              />
+            </div>
+          ))}
+        </BookRailSection>
+      ) : (
+        <div className="grid gap-4">
+          {STATUS_ORDERED.map((status) => {
+            const statusBooks = books.filter((b) => b.status === status);
+            return (
+              <BookRailSection
+                key={status}
+                title={t(`library.statusEyebrow.${status}`)}
+                eyebrow={t(`book.status.${status}`)}
+                count={statusBooks.length}
+                emptyTitle={getFilterTitle(status)}
+                emptyCopy={t(`library.statusEmpty.${status}`)}
+              >
+                {statusBooks.map((book) => (
+                  <div
+                    key={book.id}
+                    className="shrink-0 w-[clamp(260px,32vw,340px)]"
+                    style={{ scrollSnapAlign: "start" }}
+                  >
+                    <BookCardWithSelection
+                      book={book}
+                      selectionMode={selectionMode}
+                      selected={selectedIds.has(book.id)}
+                      onToggle={toggleSelect}
+                    />
+                  </div>
+                ))}
+              </BookRailSection>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Floating selection toolbar */}
+      {selectionMode && selectedIds.size > 0 && (
+        <SelectionToolbar
+          selectedCount={selectedIds.size}
+          onBatchStatusChange={handleBatchStatusChange}
+          onDeselectAll={() => setSelectedIds(new Set())}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Card wrapper with selection overlay
+// ---------------------------------------------------------------------------
+
+function BookCardWithSelection({
+  book,
+  selectionMode,
+  selected,
+  onToggle,
+}: {
+  book: LibraryBook;
+  selectionMode: boolean;
+  selected: boolean;
+  onToggle: (id: string) => void;
+}) {
+  if (!selectionMode) {
+    return <LibraryBookCard book={book} />;
+  }
+
+  return (
+    <div
+      className={cn(
+        "relative cursor-pointer transition-all duration-150",
+        selected && "ring-2 ring-accent rounded-[var(--radius-md)]",
+      )}
+      onClick={() => onToggle(book.id)}
+      role="checkbox"
+      aria-checked={selected}
+      aria-label={`${selected ? "Deselect" : "Select"} ${book.title}`}
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === " " || e.key === "Enter") {
+          e.preventDefault();
+          onToggle(book.id);
+        }
+      }}
+    >
+      <LibraryBookCard book={book} />
+
+      {/* Checkbox overlay */}
+      <div
+        className={cn(
+          "absolute top-2 left-2 w-6 h-6 rounded-full border-2 flex items-center justify-center transition-all duration-150",
+          selected
+            ? "bg-accent border-accent text-white"
+            : "bg-black/40 border-white/40 text-transparent",
+        )}
+      >
+        <span className="material-symbols-outlined text-[14px]">check</span>
+      </div>
+    </div>
+  );
+}

--- a/src/features/books/components/selection-toolbar.tsx
+++ b/src/features/books/components/selection-toolbar.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { BOOK_STATUS_VALUES, type BookStatus } from "@/lib/types/book";
+import { cn } from "@/lib/cn";
+
+interface SelectionToolbarProps {
+  selectedCount: number;
+  onBatchStatusChange: (status: BookStatus) => Promise<void>;
+  onDeselectAll: () => void;
+}
+
+export function SelectionToolbar({
+  selectedCount,
+  onBatchStatusChange,
+  onDeselectAll,
+}: SelectionToolbarProps) {
+  const t = useTranslations();
+  const [loading, setLoading] = useState<BookStatus | null>(null);
+
+  async function handleClick(status: BookStatus) {
+    setLoading(status);
+    try {
+      await onBatchStatusChange(status);
+    } finally {
+      setLoading(null);
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        "fixed bottom-20 md:bottom-6 left-1/2 -translate-x-1/2 z-40",
+        "flex items-center gap-3 px-5 py-3 rounded-2xl",
+        "bg-surface/95 border border-line shadow-[0_8px_32px_rgba(0,0,0,0.5)]",
+        "backdrop-blur-xl",
+        "animate-[fade-slide-up_250ms_ease_both]",
+      )}
+    >
+      {/* Count + deselect */}
+      <div className="flex items-center gap-2 pr-3 border-r border-line">
+        <span className="text-sm font-bold text-accent tabular-nums">
+          {t("library.selectedCount", { count: selectedCount })}
+        </span>
+        <button
+          type="button"
+          onClick={onDeselectAll}
+          className="text-xs text-muted hover:text-text transition-colors"
+        >
+          {t("library.deselectAll")}
+        </button>
+      </div>
+
+      {/* Status action pills */}
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs text-muted font-medium mr-1">
+          {t("library.moveTo")}:
+        </span>
+        {BOOK_STATUS_VALUES.map((status) => (
+          <button
+            key={status}
+            type="button"
+            disabled={loading !== null}
+            onClick={() => void handleClick(status)}
+            className={cn(
+              "px-3 py-1.5 rounded-full text-xs font-bold transition-all duration-150",
+              "border focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent",
+              loading === status
+                ? "bg-accent/20 text-accent border-accent/30 opacity-60 cursor-wait"
+                : "bg-white/6 text-muted border-white/12 hover:text-text hover:border-white/25 hover:-translate-y-px",
+            )}
+          >
+            {loading === status ? "…" : t(`book.status.${status}`)}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a selection mode to the library page for changing the status of multiple books at once. No more changing 30 books one by one.

### UX Flow

1. Tap **"Seleccionar"** button in the library header
2. Cards show **checkbox overlays** — tap to select/deselect
3. Quick actions: "Seleccionar todos" / "Ninguno"
4. **Floating toolbar** appears at the bottom with selected count + status pills
5. Tap a status pill → all selected books move to that status instantly
6. Selection mode exits automatically after the batch update

### Technical Changes

**New files:**
- `src/app/api/books/batch/route.ts` — `PATCH /api/books/batch` endpoint. Validates `bookIds[]` (max 100) + `status`. Auth-protected. Updates all matching UserBook rows for the caller.
- `src/features/books/components/library-view.tsx` — Client component wrapping the library with selection state management. Server page stays lean (data fetching only).
- `src/features/books/components/selection-toolbar.tsx` — Fixed-position floating bar with count, deselect, and status action pills.

**Modified files:**
- `src/app/library/page.tsx` — Simplified to server-only data fetching, delegates rendering to `LibraryView`.
- `messages/es.json` + `messages/en.json` — 8 new i18n keys.

### Design decisions
- **No drag & drop** — conflicts with horizontal scroll carousels on mobile
- **Floating toolbar positioned above mobile nav** (`bottom-20 md:bottom-6`)
- **Cards in selection mode are clickable as checkboxes** with ring highlight
- **`router.refresh()`** after batch update to re-fetch server data cleanly

### Verification
- `npm run lint:strict` → 0 errors
- `npx tsc --noEmit` → clean
- `npm test` → 245/245 passing