### PR TITLE
[codex] Add Donna internal API for books

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,7 @@ SUPERADMIN_EMAIL=""
 
 # Resend (email)
 RESEND_API_KEY=""
+
+# Internal API for Donna
+INTERNAL_API_KEY=""
+DONNA_USER_EMAIL=""

--- a/contracts/donna/README.md
+++ b/contracts/donna/README.md
@@ -1,0 +1,27 @@
+# Donna Internal API
+
+These contracts exist for Donna on the Pi5.
+
+## Auth
+
+- Header: `x-api-key`
+- Environment: `INTERNAL_API_KEY`
+- Donna user resolution:
+  - `DONNA_USER_EMAIL`
+  - fallback: `SUPERADMIN_EMAIL`
+
+## Endpoints
+
+- `GET /api/internal/donna/status`
+- `GET /api/internal/donna/context/summary`
+- `GET /api/internal/donna/context/library-snapshot`
+- `GET /api/internal/donna/context/recommendations`
+- `GET /api/internal/donna/context/lists`
+- `POST /api/internal/donna/context/resolve-book`
+- `POST /api/internal/donna/actions/reading-event`
+
+## Notes
+
+- Donna consumes domain DTOs, not raw Prisma models
+- `abandoned` is represented semantically through `DonnaBookState`
+- ambiguous matches must not mutate data without clarification

--- a/contracts/donna/reading-event.request.example.json
+++ b/contracts/donna/reading-event.request.example.json
@@ -1,0 +1,15 @@
+{
+  "event": "finished",
+  "bookRef": {
+    "title": "Dune",
+    "authors": ["Frank Herbert"]
+  },
+  "payload": {
+    "rating": 5,
+    "notes": "Me ha encantado"
+  },
+  "source": {
+    "channel": "telegram",
+    "actor": "Donna"
+  }
+}

--- a/contracts/donna/reading-event.response.example.json
+++ b/contracts/donna/reading-event.response.example.json
@@ -1,0 +1,28 @@
+{
+  "applied": true,
+  "resolvedBook": {
+    "id": "book_123",
+    "title": "Dune",
+    "subtitle": null,
+    "authors": ["Frank Herbert"],
+    "description": null,
+    "coverUrl": null,
+    "publisher": null,
+    "publishedDate": null,
+    "pageCount": null,
+    "isbn10": null,
+    "isbn13": "9780441172719",
+    "genres": ["Science Fiction"]
+  },
+  "resultingState": {
+    "status": "READ",
+    "semanticState": "read",
+    "rating": 5,
+    "notes": "Me ha encantado",
+    "updatedAt": "2026-04-06T18:40:00.000Z",
+    "finishedAt": "2026-04-06T18:40:00.000Z"
+  },
+  "warnings": [],
+  "matchStatus": "strong",
+  "suggestions": []
+}

--- a/contracts/donna/resolve-book.request.example.json
+++ b/contracts/donna/resolve-book.request.example.json
@@ -1,0 +1,6 @@
+{
+  "bookRef": {
+    "title": "Dune",
+    "authors": ["Frank Herbert"]
+  }
+}

--- a/contracts/donna/resolve-book.response.example.json
+++ b/contracts/donna/resolve-book.response.example.json
@@ -1,0 +1,27 @@
+{
+  "matchStatus": "strong",
+  "matchedBook": {
+    "book": {
+      "id": "book_123",
+      "title": "Dune",
+      "subtitle": null,
+      "authors": ["Frank Herbert"],
+      "description": null,
+      "coverUrl": null,
+      "publisher": null,
+      "publishedDate": null,
+      "pageCount": null,
+      "isbn10": null,
+      "isbn13": "9780441172719",
+      "genres": ["Science Fiction"]
+    },
+    "status": "TO_READ",
+    "semanticState": "to_read",
+    "rating": null,
+    "notes": null,
+    "createdAt": "2026-04-01T10:00:00.000Z",
+    "updatedAt": "2026-04-01T10:00:00.000Z",
+    "finishedAt": null
+  },
+  "suggestions": []
+}

--- a/contracts/donna/status.example.json
+++ b/contracts/donna/status.example.json
@@ -1,0 +1,11 @@
+{
+  "ok": true,
+  "owner": {
+    "userId": "usr_123",
+    "email": "carlos@example.com",
+    "name": "Carlos"
+  },
+  "contractVersion": "v1",
+  "libraryCount": 128,
+  "generatedAt": "2026-04-06T18:40:00.000Z"
+}

--- a/contracts/donna/summary.example.json
+++ b/contracts/donna/summary.example.json
@@ -1,0 +1,26 @@
+{
+  "owner": {
+    "userId": "usr_123",
+    "email": "carlos@example.com",
+    "name": "Carlos"
+  },
+  "currentlyReading": [],
+  "recentlyFinished": [],
+  "wishlistHighlights": [],
+  "topGenres": [
+    { "genre": "Fantasy", "count": 12 }
+  ],
+  "topAuthors": [
+    { "author": "Brandon Sanderson", "count": 4 }
+  ],
+  "readingStreak": {
+    "current": 3,
+    "unit": "weeks"
+  },
+  "averageRating": 4.3,
+  "abandonedCount": 2,
+  "activeLists": [
+    { "id": "list_1", "name": "Sci-Fi", "description": null, "itemCount": 18 }
+  ],
+  "profileUpdatedAt": "2026-04-06T18:40:00.000Z"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8662,17 +8662,6 @@
         }
       }
     },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.20",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.20.tgz",
-      "integrity": "sha512-2egEBHUMasdypIzrprsu8g+OEVd7Vp2MM3a2eVlM/cyFYto0nGz5BX5BTgh/ShZZI9ed+ozEq+Ngt+rgmUs8tw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -9244,7 +9233,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,16 @@ enum BookStatus {
   REREADING
 }
 
+enum DonnaSemanticState {
+  WISHLIST
+  TO_READ
+  READING
+  REREADING
+  READ
+  PAUSED
+  ABANDONED
+}
+
 enum UserRole {
   USER
   SUPERADMIN
@@ -53,6 +63,7 @@ model User {
   followers     Follow[]      @relation("following")
   following     Follow[]      @relation("followers")
   bookLists     BookList[]
+  donnaBookStates DonnaBookState[]
   loansGiven    Loan[]        @relation("lender")
   loansReceived Loan[]        @relation("borrower")
 }
@@ -158,6 +169,7 @@ model Book {
   createdAt     DateTime       @default(now())
   updatedAt     DateTime       @updatedAt
   userBooks     UserBook[]
+  donnaBookStates DonnaBookState[]
   listItems     BookListItem[]
   loans         Loan[]
 
@@ -210,6 +222,26 @@ model UserBook {
   @@unique([userId, bookId])
   @@index([userId])
   @@index([userId, status])
+  @@index([bookId])
+}
+
+model DonnaBookState {
+  id            String             @id @default(cuid())
+  userId        String
+  bookId        String
+  semanticState DonnaSemanticState
+  lastEventType String?
+  lastEventAt   DateTime?
+  source        String?
+  metadata      Json?
+  createdAt     DateTime           @default(now())
+  updatedAt     DateTime           @updatedAt
+  user          User               @relation(fields: [userId], references: [id], onDelete: Cascade)
+  book          Book               @relation(fields: [bookId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, bookId])
+  @@index([userId])
+  @@index([userId, semanticState])
   @@index([bookId])
 }
 

--- a/src/app/api/internal/donna/actions/reading-event/__tests__/route.test.ts
+++ b/src/app/api/internal/donna/actions/reading-event/__tests__/route.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  validateInternalApiKeyMock,
+  applyDonnaReadingEventMock,
+} = vi.hoisted(() => ({
+  validateInternalApiKeyMock: vi.fn(),
+  applyDonnaReadingEventMock: vi.fn(),
+}));
+
+vi.mock("@/lib/internal-api", () => ({
+  validateInternalApiKey: validateInternalApiKeyMock,
+}));
+
+vi.mock("@/lib/donna/books", () => ({
+  applyDonnaReadingEvent: applyDonnaReadingEventMock,
+}));
+
+vi.mock("@/lib/donna/user", () => ({
+  DonnaUserNotConfiguredError: class DonnaUserNotConfiguredError extends Error {},
+  DonnaUserNotFoundError: class DonnaUserNotFoundError extends Error {},
+}));
+
+import { POST } from "@/app/api/internal/donna/actions/reading-event/route";
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/internal/donna/actions/reading-event", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": "secret",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/internal/donna/actions/reading-event", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    validateInternalApiKeyMock.mockReturnValue(true);
+  });
+
+  it("returns 200 for an applied event", async () => {
+    applyDonnaReadingEventMock.mockResolvedValueOnce({
+      applied: true,
+      resolvedBook: { id: "book-1", title: "Dune" },
+      resultingState: { semanticState: "read" },
+      warnings: [],
+      matchStatus: "strong",
+      suggestions: [],
+    });
+
+    const response = await POST(makeRequest({
+      event: "finished",
+      bookRef: { title: "Dune", authors: ["Frank Herbert"] },
+      payload: {},
+      source: { channel: "telegram", actor: "Donna" },
+    }) as never);
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.applied).toBe(true);
+  });
+
+  it("returns 409 when the event cannot be applied", async () => {
+    applyDonnaReadingEventMock.mockResolvedValueOnce({
+      applied: false,
+      resolvedBook: null,
+      resultingState: null,
+      warnings: [],
+      matchStatus: "ambiguous",
+      suggestions: [{ book: { id: "book-1", title: "Dune" } }],
+    });
+
+    const response = await POST(makeRequest({
+      event: "finished",
+      bookRef: { title: "Dune" },
+      payload: {},
+      source: { channel: "telegram", actor: "Donna" },
+    }) as never);
+
+    expect(response.status).toBe(409);
+  });
+});

--- a/src/app/api/internal/donna/actions/reading-event/route.ts
+++ b/src/app/api/internal/donna/actions/reading-event/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { applyDonnaReadingEvent } from "@/lib/donna/books";
+import { readingEventRequestSchema } from "@/lib/donna/contracts";
+import { DonnaUserNotConfiguredError, DonnaUserNotFoundError } from "@/lib/donna/user";
+import { validateInternalApiKey } from "@/lib/internal-api";
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  if (!validateInternalApiKey(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = readingEventRequestSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  try {
+    const result = await applyDonnaReadingEvent(parsed.data);
+    return NextResponse.json(result, { status: result.applied ? 200 : 409 });
+  } catch (error) {
+    if (error instanceof DonnaUserNotConfiguredError || error instanceof DonnaUserNotFoundError) {
+      return NextResponse.json({ error: error.message }, { status: 503 });
+    }
+
+    console.error("[POST /api/internal/donna/actions/reading-event]", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/internal/donna/context/library-snapshot/route.ts
+++ b/src/app/api/internal/donna/context/library-snapshot/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDonnaLibrarySnapshot } from "@/lib/donna/books";
+import { DonnaUserNotConfiguredError, DonnaUserNotFoundError } from "@/lib/donna/user";
+import { validateInternalApiKey } from "@/lib/internal-api";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  if (!validateInternalApiKey(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    return NextResponse.json(await getDonnaLibrarySnapshot());
+  } catch (error) {
+    if (error instanceof DonnaUserNotConfiguredError || error instanceof DonnaUserNotFoundError) {
+      return NextResponse.json({ error: error.message }, { status: 503 });
+    }
+
+    console.error("[GET /api/internal/donna/context/library-snapshot]", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/internal/donna/context/lists/route.ts
+++ b/src/app/api/internal/donna/context/lists/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDonnaLists } from "@/lib/donna/books";
+import { DonnaUserNotConfiguredError, DonnaUserNotFoundError } from "@/lib/donna/user";
+import { validateInternalApiKey } from "@/lib/internal-api";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  if (!validateInternalApiKey(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    return NextResponse.json(await getDonnaLists());
+  } catch (error) {
+    if (error instanceof DonnaUserNotConfiguredError || error instanceof DonnaUserNotFoundError) {
+      return NextResponse.json({ error: error.message }, { status: 503 });
+    }
+
+    console.error("[GET /api/internal/donna/context/lists]", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/internal/donna/context/recommendations/route.ts
+++ b/src/app/api/internal/donna/context/recommendations/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDonnaRecommendations } from "@/lib/donna/books";
+import { DonnaUserNotConfiguredError, DonnaUserNotFoundError } from "@/lib/donna/user";
+import { validateInternalApiKey } from "@/lib/internal-api";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  if (!validateInternalApiKey(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    return NextResponse.json(await getDonnaRecommendations());
+  } catch (error) {
+    if (error instanceof DonnaUserNotConfiguredError || error instanceof DonnaUserNotFoundError) {
+      return NextResponse.json({ error: error.message }, { status: 503 });
+    }
+
+    console.error("[GET /api/internal/donna/context/recommendations]", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/internal/donna/context/resolve-book/__tests__/route.test.ts
+++ b/src/app/api/internal/donna/context/resolve-book/__tests__/route.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  validateInternalApiKeyMock,
+  resolveDonnaBookMock,
+} = vi.hoisted(() => ({
+  validateInternalApiKeyMock: vi.fn(),
+  resolveDonnaBookMock: vi.fn(),
+}));
+
+vi.mock("@/lib/internal-api", () => ({
+  validateInternalApiKey: validateInternalApiKeyMock,
+}));
+
+vi.mock("@/lib/donna/books", () => ({
+  resolveDonnaBook: resolveDonnaBookMock,
+}));
+
+vi.mock("@/lib/donna/user", () => ({
+  DonnaUserNotConfiguredError: class DonnaUserNotConfiguredError extends Error {},
+  DonnaUserNotFoundError: class DonnaUserNotFoundError extends Error {},
+}));
+
+import { POST } from "@/app/api/internal/donna/context/resolve-book/route";
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/internal/donna/context/resolve-book", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": "secret",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/internal/donna/context/resolve-book", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    validateInternalApiKeyMock.mockReturnValue(true);
+  });
+
+  it("returns the resolved book payload", async () => {
+    resolveDonnaBookMock.mockResolvedValueOnce({
+      matchStatus: "exact",
+      matchedBook: { book: { id: "book-1", title: "Dune" } },
+      suggestions: [],
+    });
+
+    const response = await POST(makeRequest({ bookRef: { isbn13: "9780441172719" } }) as never);
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(resolveDonnaBookMock).toHaveBeenCalledWith({ isbn13: "9780441172719" });
+    expect(json.matchStatus).toBe("exact");
+  });
+
+  it("returns 401 when x-api-key is invalid", async () => {
+    validateInternalApiKeyMock.mockReturnValueOnce(false);
+
+    const response = await POST(makeRequest({ bookRef: { title: "Dune" } }) as never);
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/src/app/api/internal/donna/context/resolve-book/route.ts
+++ b/src/app/api/internal/donna/context/resolve-book/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { resolveDonnaBook } from "@/lib/donna/books";
+import { resolveBookRequestSchema } from "@/lib/donna/contracts";
+import { DonnaUserNotConfiguredError, DonnaUserNotFoundError } from "@/lib/donna/user";
+import { validateInternalApiKey } from "@/lib/internal-api";
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  if (!validateInternalApiKey(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = resolveBookRequestSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  try {
+    return NextResponse.json(await resolveDonnaBook(parsed.data.bookRef));
+  } catch (error) {
+    if (error instanceof DonnaUserNotConfiguredError || error instanceof DonnaUserNotFoundError) {
+      return NextResponse.json({ error: error.message }, { status: 503 });
+    }
+
+    console.error("[POST /api/internal/donna/context/resolve-book]", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/internal/donna/context/summary/__tests__/route.test.ts
+++ b/src/app/api/internal/donna/context/summary/__tests__/route.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  validateInternalApiKeyMock,
+  getDonnaSummaryMock,
+} = vi.hoisted(() => ({
+  validateInternalApiKeyMock: vi.fn(),
+  getDonnaSummaryMock: vi.fn(),
+}));
+
+vi.mock("@/lib/internal-api", () => ({
+  validateInternalApiKey: validateInternalApiKeyMock,
+}));
+
+vi.mock("@/lib/donna/books", () => ({
+  getDonnaSummary: getDonnaSummaryMock,
+}));
+
+vi.mock("@/lib/donna/user", () => ({
+  DonnaUserNotConfiguredError: class DonnaUserNotConfiguredError extends Error {},
+  DonnaUserNotFoundError: class DonnaUserNotFoundError extends Error {},
+}));
+
+import { GET } from "@/app/api/internal/donna/context/summary/route";
+
+describe("GET /api/internal/donna/context/summary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    validateInternalApiKeyMock.mockReturnValue(true);
+  });
+
+  it("returns the summary payload", async () => {
+    getDonnaSummaryMock.mockResolvedValueOnce({
+      currentlyReading: [],
+      recentlyFinished: [],
+      wishlistHighlights: [],
+      topGenres: [],
+      topAuthors: [],
+      readingStreak: { current: 0, unit: "weeks" },
+      averageRating: null,
+      abandonedCount: 0,
+      activeLists: [],
+      profileUpdatedAt: "2026-04-06T00:00:00.000Z",
+    });
+
+    const response = await GET(new Request("http://localhost/api/internal/donna/context/summary", {
+      headers: { "x-api-key": "secret" },
+    }) as never);
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/src/app/api/internal/donna/context/summary/route.ts
+++ b/src/app/api/internal/donna/context/summary/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDonnaSummary } from "@/lib/donna/books";
+import { DonnaUserNotConfiguredError, DonnaUserNotFoundError } from "@/lib/donna/user";
+import { validateInternalApiKey } from "@/lib/internal-api";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  if (!validateInternalApiKey(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    return NextResponse.json(await getDonnaSummary());
+  } catch (error) {
+    if (error instanceof DonnaUserNotConfiguredError || error instanceof DonnaUserNotFoundError) {
+      return NextResponse.json({ error: error.message }, { status: 503 });
+    }
+
+    console.error("[GET /api/internal/donna/context/summary]", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/internal/donna/status/route.ts
+++ b/src/app/api/internal/donna/status/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDonnaStatus } from "@/lib/donna/books";
+import { DonnaUserNotConfiguredError, DonnaUserNotFoundError } from "@/lib/donna/user";
+import { validateInternalApiKey } from "@/lib/internal-api";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  if (!validateInternalApiKey(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    return NextResponse.json(await getDonnaStatus());
+  } catch (error) {
+    if (error instanceof DonnaUserNotConfiguredError || error instanceof DonnaUserNotFoundError) {
+      return NextResponse.json({ error: error.message }, { status: 503 });
+    }
+
+    console.error("[GET /api/internal/donna/status]", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/lib/donna/books.ts
+++ b/src/lib/donna/books.ts
@@ -1,0 +1,748 @@
+import "server-only";
+
+import { Prisma, type DonnaSemanticState as PrismaDonnaSemanticState } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { USER_BOOK_SELECT } from "@/lib/books/user-book-select";
+import { getViewableUserIds } from "@/lib/privacy/can-view-user-books";
+import {
+  isMissingDonnaStateSchemaError,
+  isMissingListsSchemaError,
+  isMissingSocialSchemaError,
+  isMissingUserBookSchemaError,
+} from "@/lib/prisma-schema-compat";
+import type { DonnaBookRef, DonnaSemanticState, ReadingEventRequest } from "./contracts";
+import { getDonnaUserContext } from "./user";
+
+type SelectedUserBook = Prisma.UserBookGetPayload<{ select: typeof USER_BOOK_SELECT }>;
+
+type NormalizedBook = {
+  id: string;
+  title: string;
+  subtitle: string | null;
+  authors: string[];
+  description: string | null;
+  coverUrl: string | null;
+  publisher: string | null;
+  publishedDate: string | null;
+  pageCount: number | null;
+  isbn10: string | null;
+  isbn13: string | null;
+  genres: string[];
+};
+
+type NormalizedLibraryEntry = {
+  book: NormalizedBook;
+  status: SelectedUserBook["status"];
+  semanticState: DonnaSemanticState;
+  rating: number | null;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+  finishedAt: string | null;
+};
+
+type ResolveMatchStatus = "exact" | "strong" | "ambiguous" | "none";
+
+type ResolveBookResult = {
+  matchStatus: ResolveMatchStatus;
+  matchedBook: NormalizedLibraryEntry | null;
+  suggestions: NormalizedLibraryEntry[];
+};
+
+const SEMANTIC_TO_STATUS: Record<DonnaSemanticState, "WISHLIST" | "TO_READ" | "READING" | "REREADING" | "READ" | "ON_HOLD"> = {
+  wishlist: "WISHLIST",
+  to_read: "TO_READ",
+  reading: "READING",
+  rereading: "REREADING",
+  read: "READ",
+  paused: "ON_HOLD",
+  abandoned: "ON_HOLD",
+};
+
+function normalizeBook(book: SelectedUserBook["book"]): NormalizedBook {
+  return {
+    id: book.id,
+    title: book.title,
+    subtitle: book.subtitle ?? null,
+    authors: book.authors,
+    description: book.description ?? null,
+    coverUrl: book.coverUrl ?? null,
+    publisher: book.publisher ?? null,
+    publishedDate: book.publishedDate ?? null,
+    pageCount: book.pageCount ?? null,
+    isbn10: book.isbn10 ?? null,
+    isbn13: book.isbn13 ?? null,
+    genres: book.genres,
+  };
+}
+
+function getSemanticState(
+  status: SelectedUserBook["status"],
+  overrideState?: DonnaSemanticState | null,
+): DonnaSemanticState {
+  if (overrideState) {
+    return overrideState;
+  }
+
+  switch (status) {
+    case "WISHLIST":
+      return "wishlist";
+    case "TO_READ":
+      return "to_read";
+    case "READING":
+      return "reading";
+    case "REREADING":
+      return "rereading";
+    case "READ":
+      return "read";
+    case "ON_HOLD":
+      return "paused";
+    default:
+      return "to_read";
+  }
+}
+
+function normalizeEntry(
+  entry: SelectedUserBook,
+  semanticState?: DonnaSemanticState | null,
+): NormalizedLibraryEntry {
+  return {
+    book: normalizeBook(entry.book),
+    status: entry.status,
+    semanticState: getSemanticState(entry.status, semanticState),
+    rating: entry.rating ?? null,
+    notes: entry.notes ?? null,
+    createdAt: entry.createdAt.toISOString(),
+    updatedAt: entry.updatedAt.toISOString(),
+    finishedAt: null,
+  };
+}
+
+function normalizeTitle(value: string): string {
+  return value.trim().toLocaleLowerCase();
+}
+
+function normalizeAuthorSet(value: string[] | undefined): Set<string> {
+  return new Set((value ?? []).map((author) => normalizeTitle(author)));
+}
+
+function getEventTimestamp(payload: ReadingEventRequest["payload"]): Date {
+  if (!payload.occurredAt) {
+    return new Date();
+  }
+
+  const parsed = new Date(payload.occurredAt);
+  return Number.isNaN(parsed.valueOf()) ? new Date() : parsed;
+}
+
+async function getDonnaStateMap(
+  userId: string,
+  bookIds: string[],
+): Promise<Map<string, DonnaSemanticState>> {
+  if (bookIds.length === 0) {
+    return new Map();
+  }
+
+  try {
+    const rows = await prisma.donnaBookState.findMany({
+      where: { userId, bookId: { in: bookIds } },
+      select: { bookId: true, semanticState: true },
+    });
+
+    return new Map(rows.map((row) => [
+      row.bookId,
+      row.semanticState.toLowerCase() as DonnaSemanticState,
+    ]));
+  } catch (error) {
+    if (isMissingDonnaStateSchemaError(error)) {
+      return new Map();
+    }
+    throw error;
+  }
+}
+
+async function getLibraryEntriesForUser(userId: string): Promise<NormalizedLibraryEntry[]> {
+  const rows = await prisma.userBook.findMany({
+    where: { userId },
+    select: USER_BOOK_SELECT,
+    orderBy: { updatedAt: "desc" },
+  });
+  const stateMap = await getDonnaStateMap(userId, rows.map((row) => row.bookId));
+  return rows.map((row) => normalizeEntry(row, stateMap.get(row.bookId)));
+}
+
+function computeWeeklyStreak(dates: Date[]): { current: number; unit: "weeks" } {
+  if (dates.length === 0) {
+    return { current: 0, unit: "weeks" };
+  }
+
+  const weeks = new Set<string>();
+  for (const date of dates) {
+    const copy = new Date(date);
+    const day = copy.getUTCDay() || 7;
+    copy.setUTCDate(copy.getUTCDate() + 4 - day);
+    const yearStart = new Date(Date.UTC(copy.getUTCFullYear(), 0, 1));
+    const week = Math.ceil((((copy.getTime() - yearStart.getTime()) / 86400000) + 1) / 7);
+    weeks.add(`${copy.getUTCFullYear()}-${String(week).padStart(2, "0")}`);
+  }
+
+  let current = 0;
+  const cursor = new Date();
+  while (true) {
+    const day = cursor.getUTCDay() || 7;
+    cursor.setUTCDate(cursor.getUTCDate() + 4 - day);
+    const yearStart = new Date(Date.UTC(cursor.getUTCFullYear(), 0, 1));
+    const week = Math.ceil((((cursor.getTime() - yearStart.getTime()) / 86400000) + 1) / 7);
+    const key = `${cursor.getUTCFullYear()}-${String(week).padStart(2, "0")}`;
+
+    if (!weeks.has(key)) {
+      break;
+    }
+    current += 1;
+    cursor.setUTCDate(cursor.getUTCDate() - 7);
+  }
+
+  return { current, unit: "weeks" };
+}
+
+function rankTitleCandidate(
+  candidate: SelectedUserBook,
+  ref: DonnaBookRef,
+  ownedBookIds: Set<string>,
+): number {
+  let score = 0;
+  const refTitle = ref.title ? normalizeTitle(ref.title) : "";
+  const candidateTitle = normalizeTitle(candidate.book.title);
+
+  if (refTitle && candidateTitle === refTitle) {
+    score += 50;
+  } else if (refTitle && candidateTitle.includes(refTitle)) {
+    score += 25;
+  }
+
+  const refAuthors = normalizeAuthorSet(ref.authors);
+  const candidateAuthors = normalizeAuthorSet(candidate.book.authors);
+  for (const author of refAuthors) {
+    if (candidateAuthors.has(author)) {
+      score += 20;
+    }
+  }
+
+  if (ownedBookIds.has(candidate.book.id)) {
+    score += 15;
+  }
+
+  return score;
+}
+
+async function resolveUserBookByReference(
+  userId: string,
+  ref: DonnaBookRef,
+): Promise<ResolveBookResult> {
+  if (ref.bookId) {
+    const entry = await prisma.userBook.findUnique({
+      where: { userId_bookId: { userId, bookId: ref.bookId } },
+      select: USER_BOOK_SELECT,
+    });
+
+    if (!entry) {
+      return { matchStatus: "none", matchedBook: null, suggestions: [] };
+    }
+
+    const stateMap = await getDonnaStateMap(userId, [entry.bookId]);
+    return {
+      matchStatus: "exact",
+      matchedBook: normalizeEntry(entry, stateMap.get(entry.bookId)),
+      suggestions: [],
+    };
+  }
+
+  if (ref.isbn10 || ref.isbn13) {
+    const entry = await prisma.userBook.findFirst({
+      where: {
+        userId,
+        book: {
+          OR: [
+            ...(ref.isbn10 ? [{ isbn10: ref.isbn10 }] : []),
+            ...(ref.isbn13 ? [{ isbn13: ref.isbn13 }] : []),
+          ],
+        },
+      },
+      select: USER_BOOK_SELECT,
+    });
+
+    if (!entry) {
+      return { matchStatus: "none", matchedBook: null, suggestions: [] };
+    }
+
+    const stateMap = await getDonnaStateMap(userId, [entry.bookId]);
+    return {
+      matchStatus: "exact",
+      matchedBook: normalizeEntry(entry, stateMap.get(entry.bookId)),
+      suggestions: [],
+    };
+  }
+
+  if (!ref.title) {
+    return { matchStatus: "none", matchedBook: null, suggestions: [] };
+  }
+
+  const candidates = await prisma.userBook.findMany({
+    where: {
+      userId,
+      book: {
+        title: {
+          contains: ref.title,
+          mode: "insensitive",
+        },
+      },
+    },
+    select: USER_BOOK_SELECT,
+    take: 8,
+    orderBy: { updatedAt: "desc" },
+  });
+
+  if (candidates.length === 0) {
+    return { matchStatus: "none", matchedBook: null, suggestions: [] };
+  }
+
+  const stateMap = await getDonnaStateMap(userId, candidates.map((candidate) => candidate.bookId));
+  const ownedIds = new Set(candidates.map((candidate) => candidate.bookId));
+  const scored = candidates
+    .map((candidate) => ({ candidate, score: rankTitleCandidate(candidate, ref, ownedIds) }))
+    .sort((left, right) => right.score - left.score);
+
+  if (scored[0] && scored[0].score >= 50 && (!scored[1] || scored[0].score - scored[1].score >= 20)) {
+    return {
+      matchStatus: scored[0].score >= 70 ? "exact" : "strong",
+      matchedBook: normalizeEntry(scored[0].candidate, stateMap.get(scored[0].candidate.bookId)),
+      suggestions: scored.slice(1, 4).map((item) => normalizeEntry(item.candidate, stateMap.get(item.candidate.bookId))),
+    };
+  }
+
+  return {
+    matchStatus: "ambiguous",
+    matchedBook: null,
+    suggestions: scored.slice(0, 5).map((item) => normalizeEntry(item.candidate, stateMap.get(item.candidate.bookId))),
+  };
+}
+
+async function resolveOrCreateBook(
+  userId: string,
+  ref: DonnaBookRef,
+  payload: ReadingEventRequest["payload"],
+): Promise<{ bookId: string; warnings: string[]; resolve: ResolveBookResult }> {
+  const warnings: string[] = [];
+  const resolve = await resolveUserBookByReference(userId, ref);
+
+  if (resolve.matchStatus === "exact" || resolve.matchStatus === "strong") {
+    return { bookId: resolve.matchedBook!.book.id, warnings, resolve };
+  }
+
+  if (resolve.matchStatus === "ambiguous") {
+    return { bookId: "", warnings, resolve };
+  }
+
+  const title = payload.title ?? ref.title;
+  const authors = payload.authors ?? ref.authors;
+  if (!title || !authors || authors.length === 0) {
+    return {
+      bookId: "",
+      warnings: ["Book could not be resolved and payload is insufficient to create it"],
+      resolve,
+    };
+  }
+
+  const createdBook = await prisma.book.create({
+    data: {
+      title,
+      subtitle: payload.subtitle ?? null,
+      authors,
+      description: payload.description ?? null,
+      coverUrl: payload.coverUrl ?? null,
+      publisher: payload.publisher ?? null,
+      publishedDate: payload.publishedDate ?? null,
+      pageCount: payload.pageCount ?? null,
+      isbn10: payload.isbn10 ?? ref.isbn10 ?? null,
+      isbn13: payload.isbn13 ?? ref.isbn13 ?? null,
+      genres: payload.genres ?? [],
+    },
+  });
+
+  warnings.push("Created a new Book record because the reference did not resolve to an existing title");
+  return { bookId: createdBook.id, warnings, resolve };
+}
+
+async function upsertDonnaState(
+  userId: string,
+  bookId: string,
+  semanticState: DonnaSemanticState,
+  input: ReadingEventRequest,
+): Promise<void> {
+  try {
+    await prisma.donnaBookState.upsert({
+      where: { userId_bookId: { userId, bookId } },
+      create: {
+        userId,
+        bookId,
+        semanticState: semanticState.toUpperCase() as PrismaDonnaSemanticState,
+        lastEventType: input.event,
+        lastEventAt: getEventTimestamp(input.payload),
+        source: `${input.source.channel}:${input.source.actor}`,
+        metadata: input.payload,
+      },
+      update: {
+        semanticState: semanticState.toUpperCase() as PrismaDonnaSemanticState,
+        lastEventType: input.event,
+        lastEventAt: getEventTimestamp(input.payload),
+        source: `${input.source.channel}:${input.source.actor}`,
+        metadata: input.payload,
+      },
+    });
+  } catch (error) {
+    if (!isMissingDonnaStateSchemaError(error)) {
+      throw error;
+    }
+  }
+}
+
+function nextSemanticState(
+  event: ReadingEventRequest["event"],
+  currentStatus?: SelectedUserBook["status"],
+): DonnaSemanticState | null {
+  switch (event) {
+    case "wishlisted":
+      return "wishlist";
+    case "started":
+      return currentStatus === "READ" ? "rereading" : "reading";
+    case "restarted":
+      return "rereading";
+    case "finished":
+      return "read";
+    case "paused":
+      return "paused";
+    case "abandoned":
+      return "abandoned";
+    case "rated":
+    case "noted":
+      return null;
+    default:
+      return null;
+  }
+}
+
+export async function getDonnaStatus() {
+  const user = await getDonnaUserContext();
+  const libraryCount = await prisma.userBook.count({ where: { userId: user.userId } }).catch(() => 0);
+
+  return {
+    ok: true,
+    owner: user,
+    contractVersion: "v1",
+    libraryCount,
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+export async function getDonnaSummary() {
+  const user = await getDonnaUserContext();
+  const entries = await getLibraryEntriesForUser(user.userId).catch((error) => {
+    if (isMissingUserBookSchemaError(error)) {
+      return [];
+    }
+    throw error;
+  });
+
+  let activeLists: Array<{ id: string; name: string; description: string | null; itemCount: number }> = [];
+  try {
+    activeLists = (await prisma.bookList.findMany({
+      where: { userId: user.userId },
+      include: { _count: { select: { items: true } } },
+      orderBy: { updatedAt: "desc" },
+      take: 5,
+    })).map((list) => ({
+      id: list.id,
+      name: list.name,
+      description: list.description ?? null,
+      itemCount: list._count.items,
+    }));
+  } catch (error) {
+    if (!isMissingListsSchemaError(error)) {
+      throw error;
+    }
+  }
+
+  const rated = entries.filter((entry) => entry.rating != null).map((entry) => entry.rating as number);
+  const readDates = entries
+    .filter((entry) => entry.semanticState === "read")
+    .map((entry) => new Date(entry.finishedAt ?? entry.updatedAt));
+
+  const genreCounts = new Map<string, number>();
+  const authorCounts = new Map<string, number>();
+  for (const entry of entries.filter((item) =>
+    item.semanticState === "read"
+    || item.semanticState === "reading"
+    || item.semanticState === "rereading"
+  )) {
+    for (const genre of entry.book.genres) {
+      genreCounts.set(genre, (genreCounts.get(genre) ?? 0) + 1);
+    }
+    for (const author of entry.book.authors) {
+      authorCounts.set(author, (authorCounts.get(author) ?? 0) + 1);
+    }
+  }
+
+  const byUpdatedAt = [...entries].sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+  return {
+    owner: user,
+    currentlyReading: byUpdatedAt.filter((entry) => entry.semanticState === "reading" || entry.semanticState === "rereading").slice(0, 5),
+    recentlyFinished: byUpdatedAt.filter((entry) => entry.semanticState === "read").slice(0, 5),
+    wishlistHighlights: byUpdatedAt.filter((entry) => entry.semanticState === "wishlist" || entry.semanticState === "to_read").slice(0, 5),
+    topGenres: [...genreCounts.entries()].sort((left, right) => right[1] - left[1]).slice(0, 5).map(([genre, count]) => ({ genre, count })),
+    topAuthors: [...authorCounts.entries()].sort((left, right) => right[1] - left[1]).slice(0, 5).map(([author, count]) => ({ author, count })),
+    readingStreak: computeWeeklyStreak(readDates),
+    averageRating: rated.length === 0 ? null : Math.round((rated.reduce((sum, value) => sum + value, 0) / rated.length) * 100) / 100,
+    abandonedCount: entries.filter((entry) => entry.semanticState === "abandoned").length,
+    activeLists,
+    profileUpdatedAt: byUpdatedAt[0]?.updatedAt ?? new Date().toISOString(),
+  };
+}
+
+export async function getDonnaLibrarySnapshot() {
+  const user = await getDonnaUserContext();
+  const items = await getLibraryEntriesForUser(user.userId);
+  return {
+    owner: user,
+    total: items.length,
+    items,
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+export async function resolveDonnaBook(ref: DonnaBookRef): Promise<ResolveBookResult> {
+  const user = await getDonnaUserContext();
+  return resolveUserBookByReference(user.userId, ref);
+}
+
+export async function getDonnaRecommendations() {
+  const { userId } = await getDonnaUserContext();
+  const userBookIds = await prisma.userBook.findMany({
+    where: { userId },
+    select: { bookId: true },
+  });
+  const myBookIds = new Set(userBookIds.map((row) => row.bookId));
+
+  if (myBookIds.size === 0) {
+    return { recommendations: [] };
+  }
+
+  const sharedBookUsers = await prisma.userBook.groupBy({
+    by: ["userId"],
+    where: {
+      bookId: { in: [...myBookIds] },
+      userId: { not: userId },
+    },
+    _count: true,
+    having: { userId: { _count: { gte: 1 } } },
+  });
+
+  let followingIds: string[] = [];
+  let groupMemberIds: string[] = [];
+  try {
+    const following = await prisma.follow.findMany({
+      where: { followerId: userId },
+      select: { followingId: true },
+    });
+    followingIds = following.map((item) => item.followingId);
+
+    const myGroups = await prisma.groupMember.findMany({
+      where: { userId, status: "ACCEPTED" },
+      select: { groupId: true },
+    });
+
+    if (myGroups.length > 0) {
+      const groupMembers = await prisma.groupMember.findMany({
+        where: {
+          groupId: { in: myGroups.map((group) => group.groupId) },
+          userId: { not: userId },
+          status: "ACCEPTED",
+        },
+        select: { userId: true },
+      });
+      groupMemberIds = groupMembers.map((row) => row.userId);
+    }
+  } catch (error) {
+    if (!isMissingSocialSchemaError(error)) {
+      throw error;
+    }
+  }
+
+  const similarReaderIds = new Set([
+    ...sharedBookUsers.map((item) => item.userId),
+    ...followingIds,
+    ...groupMemberIds,
+  ]);
+  const allowedReaderIds = [...await getViewableUserIds(userId, [...similarReaderIds])];
+
+  if (allowedReaderIds.length === 0) {
+    return { recommendations: [] };
+  }
+
+  const candidateBooks = await prisma.userBook.findMany({
+    where: {
+      userId: { in: allowedReaderIds },
+      status: { in: ["READ", "READING"] },
+      bookId: { notIn: [...myBookIds] },
+    },
+    select: {
+      bookId: true,
+      book: {
+        select: {
+          id: true,
+          title: true,
+          subtitle: true,
+          authors: true,
+          description: true,
+          coverUrl: true,
+          publisher: true,
+          publishedDate: true,
+          pageCount: true,
+          isbn10: true,
+          isbn13: true,
+          genres: true,
+        },
+      },
+    },
+  });
+
+  const counts = new Map<string, { book: NormalizedBook; readerCount: number }>();
+  for (const candidate of candidateBooks) {
+    const existing = counts.get(candidate.bookId);
+    if (existing) {
+      existing.readerCount += 1;
+    } else {
+      counts.set(candidate.bookId, {
+        book: {
+          id: candidate.book.id,
+          title: candidate.book.title,
+          subtitle: candidate.book.subtitle ?? null,
+          authors: candidate.book.authors,
+          description: candidate.book.description ?? null,
+          coverUrl: candidate.book.coverUrl ?? null,
+          publisher: candidate.book.publisher ?? null,
+          publishedDate: candidate.book.publishedDate ?? null,
+          pageCount: candidate.book.pageCount ?? null,
+          isbn10: candidate.book.isbn10 ?? null,
+          isbn13: candidate.book.isbn13 ?? null,
+          genres: candidate.book.genres,
+        },
+        readerCount: 1,
+      });
+    }
+  }
+
+  return {
+    recommendations: [...counts.values()].sort((left, right) => right.readerCount - left.readerCount).slice(0, 20),
+  };
+}
+
+export async function getDonnaLists() {
+  const { userId } = await getDonnaUserContext();
+
+  try {
+    const lists = await prisma.bookList.findMany({
+      where: { userId },
+      include: { _count: { select: { items: true } } },
+      orderBy: { updatedAt: "desc" },
+    });
+
+    return {
+      total: lists.length,
+      lists: lists.map((list) => ({
+        id: list.id,
+        name: list.name,
+        description: list.description ?? null,
+        itemCount: list._count.items,
+        createdAt: list.createdAt.toISOString(),
+        updatedAt: list.updatedAt.toISOString(),
+      })),
+    };
+  } catch (error) {
+    if (isMissingListsSchemaError(error)) {
+      return { total: 0, lists: [] };
+    }
+    throw error;
+  }
+}
+
+export async function applyDonnaReadingEvent(input: ReadingEventRequest) {
+  const user = await getDonnaUserContext();
+  const warnings: string[] = [];
+  const resolution = await resolveOrCreateBook(user.userId, input.bookRef, input.payload);
+
+  warnings.push(...resolution.warnings);
+  if (!resolution.bookId) {
+    return {
+      applied: false,
+      resolvedBook: null,
+      resultingState: null,
+      warnings,
+      matchStatus: resolution.resolve.matchStatus,
+      suggestions: resolution.resolve.suggestions,
+    };
+  }
+
+  const existing = await prisma.userBook.findUnique({
+    where: { userId_bookId: { userId: user.userId, bookId: resolution.bookId } },
+    select: USER_BOOK_SELECT,
+  });
+
+  const semanticState = nextSemanticState(input.event, existing?.status) ?? getSemanticState(existing?.status ?? "WISHLIST");
+  const nextStatus = (nextSemanticState(input.event, existing?.status)
+    ? SEMANTIC_TO_STATUS[semanticState]
+    : existing?.status ?? "WISHLIST");
+  const eventAt = getEventTimestamp(input.payload);
+  const nextNotes = input.payload.notes ?? existing?.notes ?? null;
+  const nextRating = input.payload.rating ?? existing?.rating ?? null;
+
+  const saved = existing
+    ? await prisma.userBook.update({
+        where: { userId_bookId: { userId: user.userId, bookId: resolution.bookId } },
+        data: {
+          status: nextStatus,
+          notes: nextNotes,
+          rating: nextRating,
+          finishedAt: nextStatus === "READ" ? eventAt : null,
+        },
+        select: USER_BOOK_SELECT,
+      })
+    : await prisma.userBook.create({
+        data: {
+          userId: user.userId,
+          bookId: resolution.bookId,
+          status: nextStatus,
+          notes: nextNotes,
+          rating: nextRating,
+          finishedAt: nextStatus === "READ" ? eventAt : null,
+        },
+        select: USER_BOOK_SELECT,
+      });
+
+  await upsertDonnaState(user.userId, resolution.bookId, semanticState, input);
+
+  return {
+    applied: true,
+    resolvedBook: normalizeBook(saved.book),
+    resultingState: {
+      status: saved.status,
+      semanticState,
+      rating: saved.rating ?? null,
+      notes: saved.notes ?? null,
+      updatedAt: saved.updatedAt.toISOString(),
+      finishedAt: nextStatus === "READ" ? eventAt.toISOString() : null,
+    },
+    warnings,
+    matchStatus: resolution.resolve.matchStatus,
+    suggestions: [],
+  };
+}

--- a/src/lib/donna/contracts.ts
+++ b/src/lib/donna/contracts.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+
+export const donnaSemanticStateSchema = z.enum([
+  "wishlist",
+  "to_read",
+  "reading",
+  "rereading",
+  "read",
+  "paused",
+  "abandoned",
+]);
+
+export const donnaBookRefSchema = z.object({
+  bookId: z.string().min(1).optional(),
+  isbn10: z.string().min(1).optional(),
+  isbn13: z.string().min(1).optional(),
+  title: z.string().min(1).optional(),
+  authors: z.array(z.string().min(1)).optional(),
+}).refine(
+  (value) => Boolean(value.bookId || value.isbn10 || value.isbn13 || value.title),
+  { message: "bookRef must include bookId, isbn10, isbn13, or title" },
+);
+
+export const readingEventSchema = z.enum([
+  "wishlisted",
+  "started",
+  "finished",
+  "paused",
+  "abandoned",
+  "rated",
+  "noted",
+  "restarted",
+]);
+
+export const readingEventPayloadSchema = z.object({
+  title: z.string().min(1).optional(),
+  subtitle: z.string().min(1).optional(),
+  authors: z.array(z.string().min(1)).optional(),
+  description: z.string().min(1).optional(),
+  coverUrl: z.string().url().optional(),
+  publisher: z.string().min(1).optional(),
+  publishedDate: z.string().min(1).optional(),
+  pageCount: z.number().int().positive().optional(),
+  isbn10: z.string().min(1).optional(),
+  isbn13: z.string().min(1).optional(),
+  genres: z.array(z.string().min(1)).optional(),
+  rating: z.number().int().min(1).max(5).optional(),
+  notes: z.string().min(1).optional(),
+  occurredAt: z.string().datetime().optional(),
+}).default({});
+
+export const readingEventRequestSchema = z.object({
+  event: readingEventSchema,
+  bookRef: donnaBookRefSchema,
+  payload: readingEventPayloadSchema,
+  source: z.object({
+    channel: z.string().min(1).default("internal"),
+    actor: z.string().min(1).default("Donna"),
+  }).default({
+    channel: "internal",
+    actor: "Donna",
+  }),
+});
+
+export const resolveBookRequestSchema = z.object({
+  bookRef: donnaBookRefSchema,
+});
+
+export type DonnaSemanticState = z.infer<typeof donnaSemanticStateSchema>;
+export type DonnaBookRef = z.infer<typeof donnaBookRefSchema>;
+export type ReadingEventRequest = z.infer<typeof readingEventRequestSchema>;

--- a/src/lib/donna/user.ts
+++ b/src/lib/donna/user.ts
@@ -1,0 +1,44 @@
+import "server-only";
+
+import { prisma } from "@/lib/prisma";
+
+export class DonnaUserNotConfiguredError extends Error {
+  constructor(message = "DONNA_USER_EMAIL or SUPERADMIN_EMAIL must be configured") {
+    super(message);
+    this.name = "DonnaUserNotConfiguredError";
+  }
+}
+
+export class DonnaUserNotFoundError extends Error {
+  constructor(email: string) {
+    super(`Donna user not found for ${email}`);
+    this.name = "DonnaUserNotFoundError";
+  }
+}
+
+export async function getDonnaUserContext(): Promise<{
+  userId: string;
+  email: string;
+  name: string | null;
+}> {
+  const email = process.env.DONNA_USER_EMAIL ?? process.env.SUPERADMIN_EMAIL;
+
+  if (!email) {
+    throw new DonnaUserNotConfiguredError();
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email },
+    select: { id: true, email: true, name: true },
+  });
+
+  if (!user) {
+    throw new DonnaUserNotFoundError(email);
+  }
+
+  return {
+    userId: user.id,
+    email: user.email,
+    name: user.name,
+  };
+}

--- a/src/lib/internal-api.ts
+++ b/src/lib/internal-api.ts
@@ -1,0 +1,17 @@
+import type { NextRequest } from "next/server";
+import crypto from "node:crypto";
+
+export function validateInternalApiKey(request: NextRequest): boolean {
+  const key = request.headers.get("x-api-key") ?? "";
+  const expected = process.env["INTERNAL_API_KEY"] ?? "";
+
+  if (expected.length === 0) {
+    return false;
+  }
+
+  const constant = "internal-api-key-comparison";
+  const keyDigest = crypto.createHmac("sha256", constant).update(key).digest();
+  const expectedDigest = crypto.createHmac("sha256", constant).update(expected).digest();
+
+  return crypto.timingSafeEqual(keyDigest, expectedDigest);
+}

--- a/src/lib/prisma-schema-compat.ts
+++ b/src/lib/prisma-schema-compat.ts
@@ -40,3 +40,10 @@ export function isMissingSocialSchemaError(error: unknown): boolean {
     && /(Invitation|invitation|GroupMember|groupMember|Follow|follow)/i.test(getErrorMessage(error))
   );
 }
+
+export function isMissingDonnaStateSchemaError(error: unknown): boolean {
+  return (
+    isPrismaSchemaMismatchError(error)
+    && /(DonnaBookState|donnaBookState|DonnaSemanticState|donnaSemanticState)/i.test(getErrorMessage(error))
+  );
+}


### PR DESCRIPTION
## What changed
- add a Donna-specific internal API namespace under `/api/internal/donna/*`
- add contract fixtures and route tests for summary, resolve-book and reading-event
- introduce `DonnaBookState` so Donna can model semantic states like `abandoned` without breaking the current UI model

## Why
Donna on the Pi needs a stable service-to-service contract for live reading state, wishlist lookups and reading-event mutations.

## Validation
- `npx tsc --noEmit`
- `npx vitest run src/app/api/internal/donna`