### PR TITLE
[codex] chore(books): harden and document existing agent platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,28 @@ jobs:
       - run: npx prisma generate
       - run: npm run test:run
 
+  mcp:
+    name: MCP Package
+    runs-on: ubuntu-latest
+    needs: [lint, type-check, test]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: mcp/rollorian-mcp/package-lock.json
+      - run: npm ci
+        working-directory: mcp/rollorian-mcp
+      - run: npm run build
+        working-directory: mcp/rollorian-mcp
+      - run: npm run smoke
+        working-directory: mcp/rollorian-mcp
+
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: [lint, type-check, test]
+    needs: [lint, type-check, test, mcp]
     services:
       postgres:
         image: postgres:16

--- a/README.md
+++ b/README.md
@@ -48,6 +48,34 @@ npm test
 npm run lint
 ```
 
+## Agent Platform
+
+`origin/main` already includes the Rollorian agent surface used by Donna and the private MCP package.
+
+- Product-facing overview: `docs/agent-platform.md`
+- Donna contract examples: `contracts/donna/README.md`
+- Private MCP package: `mcp/rollorian-mcp/README.md`
+
+The Agent API lives under `/api/agent/v1` and the authenticated settings endpoints for connection management live under `/api/agent-clients`.
+
+### Agent platform validation
+
+Root application validation:
+
+```bash
+npm run lint:strict
+npm run test:run
+```
+
+Private MCP package validation:
+
+```bash
+cd mcp/rollorian-mcp
+npm ci
+npm run build
+npm run smoke
+```
+
 ## GitHub issue enrichment
 
 This repo includes a GitHub-native issue intake and enrichment flow based on:

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -47,6 +47,24 @@ The package at `mcp/rollorian-mcp` supports:
 
 It talks only to the Agent API and never to Prisma directly.
 
+## Validation
+
+Validate the Next.js app from the repo root:
+
+```bash
+npm run lint:strict
+npm run test:run
+```
+
+Validate the private MCP package separately:
+
+```bash
+cd mcp/rollorian-mcp
+npm ci
+npm run build
+npm run smoke
+```
+
 ## Public MCP next step
 
 The public MCP should live in a separate Vercel project and reuse the same Agent API contract. That rollout is intentionally deferred until auth, scopes, audit, and docs are already stable.

--- a/mcp/rollorian-mcp/README.md
+++ b/mcp/rollorian-mcp/README.md
@@ -24,7 +24,14 @@ ROLLORIAN_MCP_HTTP_PORT=8787
 
 ```bash
 cd mcp/rollorian-mcp
-npm install
+npm ci
+```
+
+## Build and smoke test
+
+```bash
+npm run build
+npm run smoke
 ```
 
 ## Run over stdio
@@ -79,6 +86,11 @@ Default binding is loopback only so the private MCP stays local to the Pi unless
 ## Inspector
 
 Use MCP Inspector against stdio or HTTP after exporting the environment variables above.
+
+## Related docs
+
+- Product-facing overview: `../../docs/agent-platform.md`
+- Donna contract examples: `../../contracts/donna/README.md`
 
 ## Pi 5 service
 

--- a/mcp/rollorian-mcp/package.json
+++ b/mcp/rollorian-mcp/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev:stdio": "tsx src/index.ts stdio",
-    "dev:http": "tsx src/index.ts http"
+    "dev:http": "tsx src/index.ts http",
+    "smoke": "node dist/smoke.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "latest",

--- a/mcp/rollorian-mcp/src/smoke.ts
+++ b/mcp/rollorian-mcp/src/smoke.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { CallToolResultSchema, ListToolsResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import { buildRollorianMcpServer } from "./server.js";
+import type { RollorianAgentClient } from "./client.js";
+
+async function main() {
+  const mockClient = {
+    getProfile: async () => ({
+      id: "user-1",
+      name: "Carlo",
+    }),
+    getSummary: async () => ({
+      booksRead: 12,
+      currentBook: "Dune",
+    }),
+    getLibrarySnapshot: async () => ({ items: [] }),
+    resolveBook: async () => ({ matchStatus: "strong" }),
+    applyReadingEvent: async () => ({ applied: true }),
+    getRecommendations: async () => ({ items: [] }),
+    listLists: async () => ({ lists: [] }),
+  } satisfies Partial<RollorianAgentClient>;
+
+  const server = buildRollorianMcpServer(mockClient as unknown as RollorianAgentClient);
+  const client = new Client({
+    name: "rollorian-mcp-smoke",
+    version: "0.1.0",
+  });
+  const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+
+  try {
+    await Promise.all([
+      server.connect(serverTransport),
+      client.connect(clientTransport),
+    ]);
+
+    const tools = await client.request({
+      method: "tools/list",
+      params: {},
+    }, ListToolsResultSchema);
+
+    assert.equal(tools.tools.length, 6);
+    assert.ok(tools.tools.some((tool) => tool.name === "get_summary"));
+
+    const result = await client.request({
+      method: "tools/call",
+      params: {
+        name: "get_summary",
+        arguments: {},
+      },
+    }, CallToolResultSchema);
+
+    assert.equal(result.content[0]?.type, "text");
+    assert.match(result.content[0]?.type === "text" ? result.content[0].text : "", /booksRead/);
+  } finally {
+    await server.close();
+    await client.close();
+  }
+}
+
+main().catch((error) => {
+  console.error("Rollorian MCP smoke failed:", error);
+  process.exit(1);
+});

--- a/src/app/api/agent/v1/books/resolve/__tests__/route.test.ts
+++ b/src/app/api/agent/v1/books/resolve/__tests__/route.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  handleAgentRouteMock,
+  resolveAgentBookMock,
+  safeParseMock,
+} = vi.hoisted(() => ({
+  handleAgentRouteMock: vi.fn(),
+  resolveAgentBookMock: vi.fn(),
+  safeParseMock: vi.fn(),
+}));
+
+vi.mock("@/lib/agents", () => ({
+  AgentInputError: class AgentInputError extends Error {
+    status = 400;
+  },
+  handleAgentRoute: handleAgentRouteMock,
+  resolveAgentBook: resolveAgentBookMock,
+  resolveBookRequestSchema: {
+    safeParse: safeParseMock,
+  },
+}));
+
+import { POST } from "@/app/api/agent/v1/books/resolve/route";
+
+function makeRequest(body: unknown) {
+  return new NextRequest("http://localhost/api/agent/v1/books/resolve", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/agent/v1/books/resolve", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    safeParseMock.mockImplementation((value: unknown) => ({
+      success: true,
+      data: value,
+    }));
+  });
+
+  it("maps a strong match to a 200 response through the shared agent route handler", async () => {
+    const response = new Response(JSON.stringify({ ok: true }), { status: 200 });
+    resolveAgentBookMock.mockResolvedValue({
+      matchStatus: "strong",
+      matchedBook: {
+        book: {
+          id: "book-1",
+        },
+      },
+    });
+    handleAgentRouteMock.mockImplementation(async (_request, config, handler) => {
+      const result = await handler({
+        userId: "user-1",
+        owner: {
+          userId: "user-1",
+          email: "carlo@example.com",
+          name: "Carlo",
+        },
+        agentClientId: "agent-1",
+        credentialId: "credential-1",
+        agentName: "Donna",
+        agentKind: "PRIVATE_COMPANION",
+        scopes: ["books:resolve"],
+        tokenPrefix: "rla_test",
+      }, { idempotencyKey: null });
+
+      expect(config).toEqual({
+        action: "books.resolve",
+        scope: "books:resolve",
+        resourceType: "book",
+      });
+      expect(result).toEqual({
+        body: {
+          matchStatus: "strong",
+          matchedBook: {
+            book: {
+              id: "book-1",
+            },
+          },
+        },
+        status: 200,
+        resourceId: "book-1",
+      });
+
+      return response;
+    });
+
+    const result = await POST(makeRequest({
+      bookRef: {
+        title: "Dune",
+      },
+    }));
+
+    expect(result).toBe(response);
+    expect(resolveAgentBookMock).toHaveBeenCalledWith(expect.objectContaining({
+      userId: "user-1",
+    }), {
+      title: "Dune",
+    });
+  });
+
+  it("maps an ambiguous match to a 409 response", async () => {
+    resolveAgentBookMock.mockResolvedValue({
+      matchStatus: "ambiguous",
+      matchedBook: null,
+    });
+    handleAgentRouteMock.mockImplementation(async (_request, _config, handler) => {
+      const result = await handler({
+        userId: "user-1",
+        owner: {
+          userId: "user-1",
+          email: "carlo@example.com",
+          name: "Carlo",
+        },
+        agentClientId: "agent-1",
+        credentialId: "credential-1",
+        agentName: "Donna",
+        agentKind: "PRIVATE_COMPANION",
+        scopes: ["books:resolve"],
+        tokenPrefix: "rla_test",
+      }, { idempotencyKey: null });
+
+      expect(result.status).toBe(409);
+      return new Response(JSON.stringify(result.body), { status: result.status });
+    });
+
+    const result = await POST(makeRequest({
+      bookRef: {
+        title: "Dune",
+      },
+    }));
+
+    expect(result.status).toBe(409);
+  });
+});

--- a/src/app/api/agent/v1/summary/__tests__/route.test.ts
+++ b/src/app/api/agent/v1/summary/__tests__/route.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  handleAgentRouteMock,
+  getAgentSummaryMock,
+} = vi.hoisted(() => ({
+  handleAgentRouteMock: vi.fn(),
+  getAgentSummaryMock: vi.fn(),
+}));
+
+vi.mock("@/lib/agents", () => ({
+  handleAgentRoute: handleAgentRouteMock,
+  getAgentSummary: getAgentSummaryMock,
+}));
+
+import { GET } from "@/app/api/agent/v1/summary/route";
+
+describe("GET /api/agent/v1/summary", () => {
+  it("delegates to the shared agent route handler with the expected scope and action", async () => {
+    const response = new Response(JSON.stringify({ ok: true }), { status: 200 });
+    handleAgentRouteMock.mockImplementation(async (_request, config, handler) => {
+      const body = await handler({
+        userId: "user-1",
+        owner: {
+          userId: "user-1",
+          email: "carlo@example.com",
+          name: "Carlo",
+        },
+        agentClientId: "agent-1",
+        credentialId: "credential-1",
+        agentName: "Donna",
+        agentKind: "PRIVATE_COMPANION",
+        scopes: ["summary:read"],
+        tokenPrefix: "rla_test",
+      }, { idempotencyKey: null });
+
+      expect(config).toEqual({
+        action: "summary.read",
+        scope: "summary:read",
+        resourceType: "summary",
+      });
+      expect(body).toEqual({
+        body: {
+          summary: true,
+        },
+      });
+
+      return response;
+    });
+    getAgentSummaryMock.mockResolvedValue({ summary: true });
+
+    const result = await GET(new NextRequest("http://localhost/api/agent/v1/summary"));
+
+    expect(result).toBe(response);
+    expect(getAgentSummaryMock).toHaveBeenCalledWith(expect.objectContaining({
+      userId: "user-1",
+    }));
+  });
+});

--- a/src/lib/agents/audit.test.ts
+++ b/src/lib/agents/audit.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { prismaMock } = vi.hoisted(() => ({
+  prismaMock: {
+    agentAuditEvent: {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+import {
+  findSuccessfulIdempotentAuditEvent,
+  getAuditOutcomeFromStatus,
+  recordAgentAuditEvent,
+} from "@/lib/agents/audit";
+
+describe("agent audit helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.agentAuditEvent.create.mockResolvedValue({});
+  });
+
+  it("maps response statuses to audit outcomes", () => {
+    expect(getAuditOutcomeFromStatus(200)).toBe("SUCCESS");
+    expect(getAuditOutcomeFromStatus(409)).toBe("REJECTED");
+    expect(getAuditOutcomeFromStatus(500)).toBe("FAILURE");
+  });
+
+  it("records agent audit events with JSON-safe metadata", async () => {
+    await recordAgentAuditEvent({
+      userId: "user-1",
+      agentClientId: "agent-1",
+      credentialId: "credential-1",
+      action: "summary.read",
+      resourceType: "summary",
+      resourceId: "summary-1",
+      outcome: "SUCCESS",
+      idempotencyKey: "idem-1",
+      metadata: {
+        responseStatus: 200,
+        responseBody: {
+          ok: true,
+        },
+      },
+    });
+
+    expect(prismaMock.agentAuditEvent.create).toHaveBeenCalledWith({
+      data: {
+        userId: "user-1",
+        agentClientId: "agent-1",
+        credentialId: "credential-1",
+        action: "summary.read",
+        resourceType: "summary",
+        resourceId: "summary-1",
+        outcome: "SUCCESS",
+        idempotencyKey: "idem-1",
+        metadata: {
+          responseStatus: 200,
+          responseBody: {
+            ok: true,
+          },
+        },
+      },
+    });
+  });
+
+  it("rehydrates successful idempotent responses when the audit metadata includes the cached payload", async () => {
+    prismaMock.agentAuditEvent.findFirst.mockResolvedValue({
+      metadata: {
+        responseStatus: 200,
+        responseBody: {
+          applied: true,
+        },
+      },
+    });
+
+    await expect(findSuccessfulIdempotentAuditEvent({
+      agentClientId: "agent-1",
+      action: "reading-events.write",
+      idempotencyKey: "idem-1",
+    })).resolves.toEqual({
+      status: 200,
+      body: {
+        applied: true,
+      },
+    });
+  });
+
+  it("returns null when the stored audit metadata cannot be used as a cached response", async () => {
+    prismaMock.agentAuditEvent.findFirst.mockResolvedValue({
+      metadata: {
+        status: 200,
+      },
+    });
+
+    await expect(findSuccessfulIdempotentAuditEvent({
+      agentClientId: "agent-1",
+      action: "reading-events.write",
+      idempotencyKey: "idem-1",
+    })).resolves.toBeNull();
+  });
+});

--- a/src/lib/agents/context.test.ts
+++ b/src/lib/agents/context.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  prismaMock,
+  hashAgentTokenMock,
+} = vi.hoisted(() => ({
+  prismaMock: {
+    agentCredential: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    agentClient: {
+      update: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+  hashAgentTokenMock: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock("@/lib/agents/tokens", () => ({
+  hashAgentToken: hashAgentTokenMock,
+}));
+
+import { AgentAuthError, AgentScopeError } from "@/lib/agents/errors";
+import { getBearerToken, requireAgentScope, resolveAgentRequestContext } from "@/lib/agents/context";
+
+function makeRequest(headers?: HeadersInit) {
+  return new NextRequest("http://localhost/api/agent/v1/summary", {
+    headers,
+  });
+}
+
+function makeCredential(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "credential-1",
+    agentClientId: "agent-1",
+    tokenPrefix: "rla_test",
+    scopes: ["summary:read", "invalid:scope"],
+    expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+    revokedAt: null,
+    agentClient: {
+      id: "agent-1",
+      userId: "user-1",
+      name: "Donna",
+      kind: "PRIVATE_COMPANION",
+      status: "ACTIVE",
+      user: {
+        id: "user-1",
+        email: "carlo@example.com",
+        name: "Carlo",
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("agent context", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hashAgentTokenMock.mockReturnValue("hashed-token");
+    prismaMock.agentCredential.findUnique.mockResolvedValue(makeCredential());
+    prismaMock.agentCredential.update.mockResolvedValue({});
+    prismaMock.agentClient.update.mockResolvedValue({});
+    prismaMock.$transaction.mockResolvedValue([]);
+  });
+
+  it("reads the bearer token from the authorization header", () => {
+    expect(getBearerToken(makeRequest({
+      authorization: "Bearer secret-token",
+    }))).toBe("secret-token");
+  });
+
+  it("rejects requests without a bearer token", () => {
+    expect(() => getBearerToken(makeRequest())).toThrowError(new AgentAuthError("Missing Bearer token"));
+  });
+
+  it("resolves the authenticated agent context and refreshes last-used timestamps", async () => {
+    const context = await resolveAgentRequestContext(makeRequest({
+      authorization: "Bearer secret-token",
+    }));
+
+    expect(hashAgentTokenMock).toHaveBeenCalledWith("secret-token");
+    expect(prismaMock.agentCredential.findUnique).toHaveBeenCalledWith(expect.objectContaining({
+      where: { tokenHash: "hashed-token" },
+    }));
+    expect(context).toEqual({
+      userId: "user-1",
+      owner: {
+        userId: "user-1",
+        email: "carlo@example.com",
+        name: "Carlo",
+      },
+      agentClientId: "agent-1",
+      credentialId: "credential-1",
+      agentName: "Donna",
+      agentKind: "PRIVATE_COMPANION",
+      scopes: ["summary:read"],
+      tokenPrefix: "rla_test",
+    });
+    expect(prismaMock.agentCredential.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: "credential-1" },
+    }));
+    expect(prismaMock.agentClient.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: "agent-1" },
+    }));
+    expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects unknown tokens", async () => {
+    prismaMock.agentCredential.findUnique.mockResolvedValue(null);
+
+    await expect(resolveAgentRequestContext(makeRequest({
+      authorization: "Bearer secret-token",
+    }))).rejects.toThrowError(new AgentAuthError("Invalid token"));
+  });
+
+  it("rejects revoked, expired, or connection-revoked credentials", async () => {
+    prismaMock.agentCredential.findUnique.mockResolvedValueOnce(makeCredential({
+      revokedAt: new Date("2026-01-01T00:00:00.000Z"),
+    }));
+
+    await expect(resolveAgentRequestContext(makeRequest({
+      authorization: "Bearer secret-token",
+    }))).rejects.toThrowError(new AgentAuthError("Token revoked"));
+
+    prismaMock.agentCredential.findUnique.mockResolvedValueOnce(makeCredential({
+      expiresAt: new Date("2000-01-01T00:00:00.000Z"),
+    }));
+
+    await expect(resolveAgentRequestContext(makeRequest({
+      authorization: "Bearer secret-token",
+    }))).rejects.toThrowError(new AgentAuthError("Token expired"));
+
+    prismaMock.agentCredential.findUnique.mockResolvedValueOnce(makeCredential({
+      agentClient: {
+        id: "agent-1",
+        userId: "user-1",
+        name: "Donna",
+        kind: "PRIVATE_COMPANION",
+        status: "REVOKED",
+        user: {
+          id: "user-1",
+          email: "carlo@example.com",
+          name: "Carlo",
+        },
+      },
+    }));
+
+    await expect(resolveAgentRequestContext(makeRequest({
+      authorization: "Bearer secret-token",
+    }))).rejects.toThrowError(new AgentAuthError("Agent connection revoked"));
+  });
+
+  it("enforces the required scope", () => {
+    expect(() => requireAgentScope({
+      userId: "user-1",
+      owner: {
+        userId: "user-1",
+        email: "carlo@example.com",
+        name: "Carlo",
+      },
+      agentClientId: "agent-1",
+      credentialId: "credential-1",
+      agentName: "Donna",
+      agentKind: "PRIVATE_COMPANION",
+      scopes: ["summary:read"],
+      tokenPrefix: "rla_test",
+    }, "library:read")).toThrowError(new AgentScopeError("Missing required scope: library:read"));
+  });
+});

--- a/src/lib/agents/management.test.ts
+++ b/src/lib/agents/management.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  prismaMock,
+  createAgentTokenMock,
+} = vi.hoisted(() => ({
+  prismaMock: {
+    agentClient: {
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    agentCredential: {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    agentAuditEvent: {
+      findMany: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+  createAgentTokenMock: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock("@/lib/agents/tokens", () => ({
+  createAgentToken: createAgentTokenMock,
+}));
+
+import { AgentInputError } from "@/lib/agents/errors";
+import {
+  createAgentClientForUser,
+  issueAgentCredentialForUser,
+  revokeAgentClientForUser,
+} from "@/lib/agents/management";
+
+function makeClient(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "agent-1",
+    userId: "user-1",
+    name: "Donna",
+    kind: "PRIVATE_COMPANION",
+    status: "ACTIVE",
+    createdAt: new Date("2026-04-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+    lastUsedAt: null,
+    credentials: [
+      {
+        id: "credential-1",
+        tokenPrefix: "rla_test",
+        scopes: ["summary:read"],
+        createdAt: new Date("2026-04-01T00:00:00.000Z"),
+        expiresAt: null,
+        revokedAt: null,
+        lastUsedAt: null,
+      },
+    ],
+    auditEvents: [
+      {
+        id: "event-1",
+        action: "summary.read",
+        outcome: "SUCCESS",
+        resourceType: "summary",
+        resourceId: "summary-1",
+        idempotencyKey: null,
+        createdAt: new Date("2026-04-01T00:00:00.000Z"),
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("agent management", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createAgentTokenMock.mockReturnValue({
+      plainToken: "plain-token",
+      tokenHash: "hashed-token",
+      tokenPrefix: "rla_test",
+    });
+    prismaMock.agentClient.create.mockResolvedValue(makeClient());
+    prismaMock.agentClient.findFirst.mockResolvedValue(makeClient());
+    prismaMock.agentCredential.create.mockResolvedValue({});
+    prismaMock.agentCredential.findFirst.mockResolvedValue({
+      id: "credential-1",
+      revokedAt: null,
+    });
+    prismaMock.agentCredential.update.mockResolvedValue({});
+    prismaMock.agentCredential.updateMany.mockResolvedValue({});
+    prismaMock.agentAuditEvent.findMany.mockResolvedValue([]);
+    prismaMock.$transaction.mockResolvedValue([]);
+  });
+
+  it("creates an agent client with deduplicated valid scopes and returns the plain token once", async () => {
+    const result = await createAgentClientForUser("user-1", {
+      name: " Donna ",
+      kind: "PRIVATE_COMPANION",
+      scopes: ["summary:read", "summary:read", "lists:read"],
+      expiresInDays: 7,
+    });
+
+    expect(prismaMock.agentClient.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        userId: "user-1",
+        name: "Donna",
+        credentials: {
+          create: expect.objectContaining({
+            tokenHash: "hashed-token",
+            tokenPrefix: "rla_test",
+            scopes: ["summary:read", "lists:read"],
+          }),
+        },
+      }),
+    }));
+    expect(result.plainToken).toBe("plain-token");
+    expect(result.client.credentials).toHaveLength(1);
+  });
+
+  it("rejects invalid scopes before issuing a new credential", async () => {
+    await expect(issueAgentCredentialForUser("user-1", "agent-1", {
+      scopes: ["summary:read", "nope:scope" as never],
+      expiresInDays: 7,
+    })).rejects.toThrowError(new AgentInputError("Invalid scopes: nope:scope"));
+
+    expect(prismaMock.agentCredential.create).not.toHaveBeenCalled();
+  });
+
+  it("revokes a client and all active credentials in one transaction", async () => {
+    await revokeAgentClientForUser("user-1", "agent-1");
+
+    expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+    expect(prismaMock.agentClient.update).toHaveBeenCalledWith({
+      where: { id: "agent-1" },
+      data: { status: "REVOKED" },
+    });
+    expect(prismaMock.agentCredential.updateMany).toHaveBeenCalledWith({
+      where: { agentClientId: "agent-1", revokedAt: null },
+      data: { revokedAt: expect.any(Date) },
+    });
+  });
+});


### PR DESCRIPTION
## What changed
- added focused coverage for `src/lib/agents` auth, audit, scope, and connection-management behavior
- added representative Agent API route smoke tests for summary reads and book resolution, alongside the existing reading-events coverage
- added a real MCP smoke script in `mcp/rollorian-mcp` using the MCP SDK in-memory transport and wired CI to build and smoke-test the package
- refreshed the root and MCP documentation so the agent-platform validation and setup flow is explicit

## Why
`origin/main` already had the Books agent platform in place, but the operational hardening was incomplete:
- no dedicated regression coverage for core agent auth/audit flows
- no CI enforcement that the private MCP package still built and could answer a basic tool call
- docs did not clearly centralize how to validate and use the agent platform

## Impact
- Books becomes the verified baseline for the MCP/Agent Platform rollout to Oura and Todo
- regressions in token handling, audit caching, scope enforcement, and MCP packaging should fail before merge
- the validation path for local development and CI is now obvious from the repo docs

## Validation
- `npm run test:run`
- `npm run lint:strict`
- `npx tsc --noEmit`
- `cd mcp/rollorian-mcp && npm run build`
- `cd mcp/rollorian-mcp && npm run smoke`