### PR TITLE
feat(settings): add self-service MCP onboarding

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -69,6 +69,41 @@
         "api": "Use the Agent API directly for scripts, automations, or assistants that do not speak MCP.",
         "mcp": "Use the same token in your private MCP package so desktop agents can call Rollorian tools."
       },
+      "onboarding": {
+        "title": "Provider onboarding",
+        "description": "Pick your MCP client and copy the ready-to-paste snippet. They all use the same Agent API token and your local private MCP.",
+        "baseUrlLabel": "Detected base URL",
+        "repoPathLabel": "Local path to replace",
+        "repoPathHelp": "Replace this path with the real location of your local clone before pasting the command or JSON.",
+        "liveToken": "These instructions already include the latest token issued in this session.",
+        "placeholderToken": "No token is visible yet. Snippets use <TOKEN> until you create or rotate a credential.",
+        "copy": "Copy",
+        "copied": "Copied",
+        "snippetLabel": {
+          "command": "Ready-to-paste command",
+          "json": "JSON configuration",
+          "env": "Shared environment",
+          "curl": "Agent API smoke test"
+        },
+        "provider": {
+          "codex": {
+            "title": "Codex",
+            "description": "Register the MCP from the Codex CLI. The configuration is shared with the extension or desktop."
+          },
+          "claude": {
+            "title": "Claude Code",
+            "description": "Register the stdio server with `claude mcp add` and reuse the same private token."
+          },
+          "cursor": {
+            "title": "Cursor",
+            "description": "Paste this block into `~/.cursor/mcp.json` or `.cursor/mcp.json` inside the project you want to use."
+          },
+          "generic": {
+            "title": "Generic MCP client",
+            "description": "Use this stdio template if your client expects command, args, and env, or smoke-test the Agent API directly first."
+          }
+        }
+      },
       "connections": {
         "title": "Existing connections",
         "description": "Every connection maps to one user-owned agent client and can carry multiple revocable credentials.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -69,6 +69,41 @@
         "api": "Usa la Agent API directamente para scripts, automatizaciones o asistentes que no hablen MCP.",
         "mcp": "Usa el mismo token en tu paquete MCP privado para que los agentes de escritorio puedan invocar herramientas de Rollorian."
       },
+      "onboarding": {
+        "title": "Onboarding por proveedor",
+        "description": "Elige tu cliente MCP y copia el snippet listo para pegar. Todos usan el mismo token de Agent API y tu MCP privado en local.",
+        "baseUrlLabel": "Base URL detectada",
+        "repoPathLabel": "Ruta local a sustituir",
+        "repoPathHelp": "Sustituye esta ruta por la ubicación real de tu clon local antes de pegar el comando o el JSON.",
+        "liveToken": "Estas instrucciones ya incluyen el último token emitido en esta sesión.",
+        "placeholderToken": "Todavía no hay token visible. Los snippets usan <TOKEN> hasta que crees o rotes una credencial.",
+        "copy": "Copiar",
+        "copied": "Copiado",
+        "snippetLabel": {
+          "command": "Comando listo para pegar",
+          "json": "Configuración JSON",
+          "env": "Variables comunes",
+          "curl": "Smoke test de la Agent API"
+        },
+        "provider": {
+          "codex": {
+            "title": "Codex",
+            "description": "Registra el MCP desde la CLI de Codex. La configuración se comparte con la extensión o desktop."
+          },
+          "claude": {
+            "title": "Claude Code",
+            "description": "Da de alta el servidor stdio con `claude mcp add` y reutiliza el mismo token privado."
+          },
+          "cursor": {
+            "title": "Cursor",
+            "description": "Pega este bloque en `~/.cursor/mcp.json` o en `.cursor/mcp.json` dentro del proyecto que quieras usar."
+          },
+          "generic": {
+            "title": "Cliente MCP genérico",
+            "description": "Usa esta plantilla stdio si tu cliente espera command, args y env, o prueba antes la Agent API directamente."
+          }
+        }
+      },
       "connections": {
         "title": "Conexiones existentes",
         "description": "Cada conexión corresponde a un cliente de agente del usuario y puede tener varias credenciales revocables.",

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,66 @@
+schema: spec-driven
+
+context: |
+  Tech stack: Next.js 16 App Router, React 19, TypeScript 5, Prisma 7, NextAuth 5 beta, next-intl 4, Tailwind CSS 4.
+  Architecture: Server-first App Router with route handlers under src/app/api, feature-oriented UI under src/features, and agent platform modules grouped in src/lib/agents.
+  Persistence: Prisma configured for PostgreSQL, with authenticated user-scoped agent management and a private MCP package under mcp/rollorian-mcp.
+  Testing: Vitest 4 for unit/integration, Testing Library dependencies available, Playwright for E2E, V8 coverage via vitest run --coverage.
+  Style: ESLint 9 (Next core-web-vitals), strict TypeScript in source even without a dedicated typecheck script, no formatter script detected.
+  Conventions: Project instructions live in AGENTS.md and require short responses, conventional commits, and no build after changes.
+
+strict_tdd: true
+
+testing:
+  detected: 2026-04-22
+  strict_tdd: true
+  note: "Strict TDD Mode is enabled by default because the project has a working test runner and no prior openspec config overrides it."
+  test_runner:
+    available: true
+    framework: "Vitest 4"
+    command: "npm run test:run"
+  layers:
+    unit:
+      available: true
+      tool: "Vitest"
+    integration:
+      available: true
+      tool: "Vitest + Testing Library"
+    e2e:
+      available: true
+      tool: "Playwright"
+  coverage:
+    available: true
+    command: "npm run test:coverage"
+  quality_tools:
+    linter:
+      available: true
+      command: "npm run lint:strict"
+    type_checker:
+      available: false
+      command: "—"
+    formatter:
+      available: false
+      command: "—"
+
+rules:
+  proposal:
+    - Include rollback plan for risky changes
+    - Identify affected modules/packages
+  specs:
+    - Use Given/When/Then format for scenarios
+    - Use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY)
+  design:
+    - Include sequence diagrams for complex flows
+    - Document architecture decisions with rationale
+  tasks:
+    - Group tasks by phase (infrastructure, implementation, testing)
+    - Use hierarchical numbering (1.1, 1.2, etc.)
+    - Keep tasks small enough to complete in one session
+  apply:
+    - Follow existing code patterns and conventions
+    - Load relevant coding skills for the project stack
+  verify:
+    - Run tests if test infrastructure exists
+    - Compare implementation against every spec scenario
+  archive:
+    - Warn before merging destructive deltas (large removals)

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -5,8 +5,9 @@ context: |
   Architecture: Server-first App Router with route handlers under src/app/api, feature-oriented UI under src/features, and agent platform modules grouped in src/lib/agents.
   Persistence: Prisma configured for PostgreSQL, with authenticated user-scoped agent management and a private MCP package under mcp/rollorian-mcp.
   Testing: Vitest 4 for unit/integration, Testing Library dependencies available, Playwright for E2E, V8 coverage via vitest run --coverage.
-  Style: ESLint 9 (Next core-web-vitals), strict TypeScript in source even without a dedicated typecheck script, no formatter script detected.
+  Style: ESLint 9 (Next core-web-vitals), strict TypeScript in source with a dedicated npm run typecheck gate, no formatter script detected.
   Conventions: Project instructions live in AGENTS.md and require short responses, conventional commits, and no build after changes.
+  Quality gates: Next.js/Vercel PR builds execute TypeScript checking, so local verification for TS/TSX changes must include npm run typecheck before pushing.
 
 strict_tdd: true
 
@@ -36,8 +37,8 @@ testing:
       available: true
       command: "npm run lint:strict"
     type_checker:
-      available: false
-      command: "—"
+      available: true
+      command: "npm run typecheck"
     formatter:
       available: false
       command: "—"
@@ -59,8 +60,10 @@ rules:
   apply:
     - Follow existing code patterns and conventions
     - Load relevant coding skills for the project stack
+    - When touching TypeScript or TSX files, run npm run typecheck before pushing to avoid PR-only failures
   verify:
     - Run tests if test infrastructure exists
     - Compare implementation against every spec scenario
+    - For TypeScript or TSX changes, include npm run typecheck in local verification because hosted PR builds enforce it
   archive:
     - Warn before merging destructive deltas (large removals)

--- a/openspec/specs/developer-validation/spec.md
+++ b/openspec/specs/developer-validation/spec.md
@@ -1,0 +1,36 @@
+# Developer Validation Specification
+
+## Purpose
+
+Define the local quality gates that MUST pass before a TypeScript change is pushed for PR review.
+
+## Requirements
+
+### Requirement: Dedicated Typecheck Command
+
+The project MUST expose a dedicated static typecheck command that validates TypeScript and TSX changes without running a production build.
+
+#### Scenario: Developer runs the static typecheck gate
+
+- GIVEN a developer has a local checkout of the project
+- WHEN they run `npm run typecheck`
+- THEN TypeScript diagnostics MUST be evaluated with `tsc --noEmit`
+- AND no production build artifacts SHALL be generated
+
+### Requirement: Pre-PR Verification for TypeScript Changes
+
+The project MUST treat `npm run typecheck` as part of local verification for any change that touches TypeScript or TSX files before the change is pushed or updated in a pull request.
+
+#### Scenario: TypeScript changes are prepared for a pull request
+
+- GIVEN a change modifies one or more `.ts` or `.tsx` files
+- WHEN the developer prepares the branch for a pull request
+- THEN local verification MUST include `npm run typecheck`
+- AND the branch SHOULD also run the repo's normal lint and test commands for the affected flow
+
+#### Scenario: Tests pass but typecheck fails
+
+- GIVEN lint or test commands pass for a TypeScript change
+- WHEN `npm run typecheck` reports an error
+- THEN the change MUST still be treated as failing verification
+- AND the developer MUST fix the type error before relying on PR build feedback

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.11.1",

--- a/src/app/api/agent-clients/[agentClientId]/credentials/[credentialId]/revoke/__tests__/route.test.ts
+++ b/src/app/api/agent-clients/[agentClientId]/credentials/[credentialId]/revoke/__tests__/route.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  revokeAgentCredentialForUserMock,
+  listRecentAgentAuditEventsForUserMock,
+  loggerErrorMock,
+} = vi.hoisted(() => ({
+  revokeAgentCredentialForUserMock: vi.fn(),
+  listRecentAgentAuditEventsForUserMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
+}));
+
+vi.mock("@/lib/agents", () => ({
+  revokeAgentCredentialForUser: revokeAgentCredentialForUserMock,
+  listRecentAgentAuditEventsForUser: listRecentAgentAuditEventsForUserMock,
+}));
+
+vi.mock("@/lib/agents/errors", () => ({
+  getErrorStatus: (error: { status?: number }) => error.status ?? 500,
+  getPublicErrorMessage: (error: Error) => error.message,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: loggerErrorMock,
+  },
+}));
+
+import { POST } from "@/app/api/agent-clients/[agentClientId]/credentials/[credentialId]/revoke/route";
+
+describe("POST /api/agent-clients/[agentClientId]/credentials/[credentialId]/revoke", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    revokeAgentCredentialForUserMock.mockResolvedValue({ id: "client-1", name: "Donna", kind: "MCP_CLIENT", status: "ACTIVE", createdAt: "2026-04-22T10:00:00.000Z", updatedAt: "2026-04-22T10:12:00.000Z", lastUsedAt: null, credentials: [], recentEvents: [] });
+    listRecentAgentAuditEventsForUserMock.mockResolvedValue([{ id: "event-4", action: "credential.revoked", outcome: "SUCCESS", resourceType: null, resourceId: null, idempotencyKey: null, createdAt: "2026-04-22T10:12:00.000Z" }]);
+  });
+
+  it("returns the updated client plus refreshed recent events", async () => {
+    const response = await POST(new Request("http://localhost/api/agent-clients/client-1/credentials/cred-1/revoke", { method: "POST" }), {
+      params: Promise.resolve({ agentClientId: "client-1", credentialId: "cred-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      client: expect.objectContaining({ id: "client-1" }),
+      recentEvents: expect.any(Array),
+    });
+  });
+});

--- a/src/app/api/agent-clients/[agentClientId]/credentials/[credentialId]/revoke/route.ts
+++ b/src/app/api/agent-clients/[agentClientId]/credentials/[credentialId]/revoke/route.ts
@@ -1,4 +1,4 @@
-import { revokeAgentCredentialForUser } from "@/lib/agents";
+import { listRecentAgentAuditEventsForUser, revokeAgentCredentialForUser } from "@/lib/agents";
 import { getErrorStatus, getPublicErrorMessage } from "@/lib/agents/errors";
 import { requireAuth, UnauthorizedError } from "@/lib/auth/require-auth";
 import { logger } from "@/lib/logger";
@@ -11,8 +11,9 @@ export async function POST(
     const { userId } = await requireAuth();
     const { agentClientId, credentialId } = await context.params;
     const client = await revokeAgentCredentialForUser(userId, agentClientId, credentialId);
+    const recentEvents = await listRecentAgentAuditEventsForUser(userId);
 
-    return Response.json({ client });
+    return Response.json({ client, recentEvents });
   } catch (error) {
     if (error instanceof UnauthorizedError) {
       return Response.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/agent-clients/[agentClientId]/credentials/__tests__/route.test.ts
+++ b/src/app/api/agent-clients/[agentClientId]/credentials/__tests__/route.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  issueAgentCredentialForUserMock,
+  listRecentAgentAuditEventsForUserMock,
+  loggerErrorMock,
+} = vi.hoisted(() => ({
+  issueAgentCredentialForUserMock: vi.fn(),
+  listRecentAgentAuditEventsForUserMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
+}));
+
+vi.mock("@/lib/agents", () => ({
+  issueAgentCredentialForUser: issueAgentCredentialForUserMock,
+  issueAgentCredentialSchema: {
+    safeParse: (value: unknown) => ({ success: true, data: value }),
+  },
+  listRecentAgentAuditEventsForUser: listRecentAgentAuditEventsForUserMock,
+}));
+
+vi.mock("@/lib/agents/errors", () => ({
+  AgentInputError: class AgentInputError extends Error {
+    status = 400;
+  },
+  getErrorStatus: (error: { status?: number }) => error.status ?? 500,
+  getPublicErrorMessage: (error: Error) => error.message,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: loggerErrorMock,
+  },
+}));
+
+import { POST } from "@/app/api/agent-clients/[agentClientId]/credentials/route";
+
+describe("POST /api/agent-clients/[agentClientId]/credentials", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    issueAgentCredentialForUserMock.mockResolvedValue({
+      client: { id: "client-1", name: "Donna", kind: "MCP_CLIENT", status: "ACTIVE", createdAt: "2026-04-22T10:00:00.000Z", updatedAt: "2026-04-22T10:00:00.000Z", lastUsedAt: null, credentials: [], recentEvents: [] },
+      plainToken: "rla_rotated_token",
+    });
+    listRecentAgentAuditEventsForUserMock.mockResolvedValue([{ id: "event-2", action: "credential.issued", outcome: "SUCCESS", resourceType: null, resourceId: null, idempotencyKey: null, createdAt: "2026-04-22T10:05:00.000Z" }]);
+  });
+
+  it("returns the rotated token and refreshed recent events", async () => {
+    const response = await POST(
+      new NextRequest("http://localhost/api/agent-clients/client-1/credentials", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ scopes: ["library:read"] }),
+      }),
+      { params: Promise.resolve({ agentClientId: "client-1" }) },
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      client: expect.objectContaining({ id: "client-1" }),
+      plainToken: "rla_rotated_token",
+      recentEvents: expect.any(Array),
+    });
+  });
+});

--- a/src/app/api/agent-clients/[agentClientId]/credentials/route.ts
+++ b/src/app/api/agent-clients/[agentClientId]/credentials/route.ts
@@ -1,5 +1,9 @@
 import type { NextRequest } from "next/server";
-import { issueAgentCredentialForUser, issueAgentCredentialSchema } from "@/lib/agents";
+import {
+  issueAgentCredentialForUser,
+  issueAgentCredentialSchema,
+  listRecentAgentAuditEventsForUser,
+} from "@/lib/agents";
 import { AgentInputError, getErrorStatus, getPublicErrorMessage } from "@/lib/agents/errors";
 import { requireAuth, UnauthorizedError } from "@/lib/auth/require-auth";
 import { logger } from "@/lib/logger";
@@ -19,7 +23,8 @@ export async function POST(
     }
 
     const result = await issueAgentCredentialForUser(userId, agentClientId, parsed.data);
-    return Response.json(result, { status: 201 });
+    const recentEvents = await listRecentAgentAuditEventsForUser(userId);
+    return Response.json({ ...result, recentEvents }, { status: 201 });
   } catch (error) {
     if (error instanceof UnauthorizedError) {
       return Response.json({ error: "Unauthorized" }, { status: 401 });
@@ -33,4 +38,3 @@ export async function POST(
     return Response.json({ error: getPublicErrorMessage(error) }, { status });
   }
 }
-

--- a/src/app/api/agent-clients/[agentClientId]/revoke/__tests__/route.test.ts
+++ b/src/app/api/agent-clients/[agentClientId]/revoke/__tests__/route.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  revokeAgentClientForUserMock,
+  listRecentAgentAuditEventsForUserMock,
+  loggerErrorMock,
+} = vi.hoisted(() => ({
+  revokeAgentClientForUserMock: vi.fn(),
+  listRecentAgentAuditEventsForUserMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
+}));
+
+vi.mock("@/lib/agents", () => ({
+  revokeAgentClientForUser: revokeAgentClientForUserMock,
+  listRecentAgentAuditEventsForUser: listRecentAgentAuditEventsForUserMock,
+}));
+
+vi.mock("@/lib/agents/errors", () => ({
+  getErrorStatus: (error: { status?: number }) => error.status ?? 500,
+  getPublicErrorMessage: (error: Error) => error.message,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: loggerErrorMock,
+  },
+}));
+
+import { POST } from "@/app/api/agent-clients/[agentClientId]/revoke/route";
+
+describe("POST /api/agent-clients/[agentClientId]/revoke", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    revokeAgentClientForUserMock.mockResolvedValue({ id: "client-1", name: "Donna", kind: "MCP_CLIENT", status: "REVOKED", createdAt: "2026-04-22T10:00:00.000Z", updatedAt: "2026-04-22T10:10:00.000Z", lastUsedAt: null, credentials: [], recentEvents: [] });
+    listRecentAgentAuditEventsForUserMock.mockResolvedValue([{ id: "event-3", action: "client.revoked", outcome: "SUCCESS", resourceType: null, resourceId: null, idempotencyKey: null, createdAt: "2026-04-22T10:10:00.000Z" }]);
+  });
+
+  it("returns the revoked client plus refreshed recent events", async () => {
+    const response = await POST(new Request("http://localhost/api/agent-clients/client-1/revoke", { method: "POST" }), {
+      params: Promise.resolve({ agentClientId: "client-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      client: expect.objectContaining({ status: "REVOKED" }),
+      recentEvents: expect.any(Array),
+    });
+  });
+});

--- a/src/app/api/agent-clients/[agentClientId]/revoke/route.ts
+++ b/src/app/api/agent-clients/[agentClientId]/revoke/route.ts
@@ -1,4 +1,4 @@
-import { revokeAgentClientForUser } from "@/lib/agents";
+import { listRecentAgentAuditEventsForUser, revokeAgentClientForUser } from "@/lib/agents";
 import { getErrorStatus, getPublicErrorMessage } from "@/lib/agents/errors";
 import { requireAuth, UnauthorizedError } from "@/lib/auth/require-auth";
 import { logger } from "@/lib/logger";
@@ -11,8 +11,9 @@ export async function POST(
     const { userId } = await requireAuth();
     const { agentClientId } = await context.params;
     const client = await revokeAgentClientForUser(userId, agentClientId);
+    const recentEvents = await listRecentAgentAuditEventsForUser(userId);
 
-    return Response.json({ client });
+    return Response.json({ client, recentEvents });
   } catch (error) {
     if (error instanceof UnauthorizedError) {
       return Response.json({ error: "Unauthorized" }, { status: 401 });
@@ -26,4 +27,3 @@ export async function POST(
     return Response.json({ error: getPublicErrorMessage(error) }, { status });
   }
 }
-

--- a/src/app/api/agent-clients/__tests__/route.test.ts
+++ b/src/app/api/agent-clients/__tests__/route.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { UnauthorizedError } from "@/lib/auth/require-auth";
+
+const {
+  createAgentClientForUserMock,
+  listAgentClientsForUserMock,
+  listRecentAgentAuditEventsForUserMock,
+  loggerErrorMock,
+} = vi.hoisted(() => ({
+  createAgentClientForUserMock: vi.fn(),
+  listAgentClientsForUserMock: vi.fn(),
+  listRecentAgentAuditEventsForUserMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
+}));
+
+vi.mock("@/lib/agents", () => ({
+  createAgentClientForUser: createAgentClientForUserMock,
+  createAgentClientSchema: {
+    safeParse: (value: unknown) => ({ success: true, data: value }),
+  },
+  listAgentClientsForUser: listAgentClientsForUserMock,
+  listRecentAgentAuditEventsForUser: listRecentAgentAuditEventsForUserMock,
+}));
+
+vi.mock("@/lib/agents/errors", () => ({
+  AgentInputError: class AgentInputError extends Error {
+    status = 400;
+  },
+  getErrorStatus: (error: { status?: number }) => error.status ?? 500,
+  getPublicErrorMessage: (error: Error) => error.message,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: loggerErrorMock,
+  },
+}));
+
+import { GET, POST } from "@/app/api/agent-clients/route";
+
+describe("/api/agent-clients route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listRecentAgentAuditEventsForUserMock.mockResolvedValue([{ id: "event-1", action: "agent.created", outcome: "SUCCESS", resourceType: null, resourceId: null, idempotencyKey: null, createdAt: "2026-04-22T10:00:00.000Z" }]);
+    listAgentClientsForUserMock.mockResolvedValue([{ id: "client-1", name: "Donna", kind: "MCP_CLIENT", status: "ACTIVE", createdAt: "2026-04-22T10:00:00.000Z", updatedAt: "2026-04-22T10:00:00.000Z", lastUsedAt: null, credentials: [], recentEvents: [] }]);
+    createAgentClientForUserMock.mockResolvedValue({
+      client: { id: "client-1", name: "Donna", kind: "MCP_CLIENT", status: "ACTIVE", createdAt: "2026-04-22T10:00:00.000Z", updatedAt: "2026-04-22T10:00:00.000Z", lastUsedAt: null, credentials: [], recentEvents: [] },
+      plainToken: "rla_live_token",
+    });
+  });
+
+  it("returns clients and recent events on GET", async () => {
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      clients: expect.any(Array),
+      recentEvents: expect.any(Array),
+    });
+  });
+
+  it("returns the created client plus refreshed recent events on POST", async () => {
+    const response = await POST(new Request("http://localhost/api/agent-clients", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Donna", kind: "MCP_CLIENT", scopes: ["library:read"] }),
+    }) as never);
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      client: expect.objectContaining({ id: "client-1" }),
+      plainToken: "rla_live_token",
+      recentEvents: expect.any(Array),
+    });
+    expect(listRecentAgentAuditEventsForUserMock).toHaveBeenCalledWith("test-user-001");
+  });
+
+  it("returns 401 when auth fails", async () => {
+    const { requireAuth } = await import("@/lib/auth/require-auth");
+    vi.mocked(requireAuth).mockRejectedValueOnce(new UnauthorizedError());
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/src/app/api/agent-clients/route.ts
+++ b/src/app/api/agent-clients/route.ts
@@ -1,8 +1,17 @@
 import type { NextRequest } from "next/server";
-import { createAgentClientSchema, createAgentClientForUser, listAgentClientsForUser, listRecentAgentAuditEventsForUser } from "@/lib/agents";
+import {
+  createAgentClientSchema,
+  createAgentClientForUser,
+  listAgentClientsForUser,
+  listRecentAgentAuditEventsForUser,
+} from "@/lib/agents";
 import { AgentInputError, getErrorStatus, getPublicErrorMessage } from "@/lib/agents/errors";
 import { requireAuth, UnauthorizedError } from "@/lib/auth/require-auth";
 import { logger } from "@/lib/logger";
+
+async function listRecentEvents(userId: string) {
+  return listRecentAgentAuditEventsForUser(userId);
+}
 
 export async function GET(): Promise<Response> {
   try {
@@ -34,7 +43,8 @@ export async function POST(request: NextRequest): Promise<Response> {
     }
 
     const result = await createAgentClientForUser(userId, parsed.data);
-    return Response.json(result, { status: 201 });
+    const recentEvents = await listRecentEvents(userId);
+    return Response.json({ ...result, recentEvents }, { status: 201 });
   } catch (error) {
     if (error instanceof UnauthorizedError) {
       return Response.json({ error: "Unauthorized" }, { status: 401 });
@@ -49,4 +59,3 @@ export async function POST(request: NextRequest): Promise<Response> {
     return Response.json({ error: getPublicErrorMessage(error) }, { status });
   }
 }
-

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,12 +1,41 @@
 import { getTranslations } from "next-intl/server";
+import { headers } from "next/headers";
 import { AgentSettingsPanel } from "@/features/settings/components/agent-settings-panel";
 import { requireAuth } from "@/lib/auth/require-auth";
 import { listAgentClientsForUser, listRecentAgentAuditEventsForUser } from "@/lib/agents";
+import { env } from "@/lib/env";
+
+function resolveBaseUrl({
+  headerHost,
+  headerProtocol,
+}: {
+  headerHost: string | null;
+  headerProtocol: string | null;
+}): string {
+  if (env.NEXTAUTH_URL) {
+    return env.NEXTAUTH_URL;
+  }
+
+  if (headerHost) {
+    return `${headerProtocol ?? "https"}://${headerHost}`;
+  }
+
+  if (env.VERCEL_URL) {
+    return `https://${env.VERCEL_URL}`;
+  }
+
+  return "https://your-rollorian.vercel.app";
+}
 
 export default async function SettingsPage() {
+  const headersList = await headers();
   const tNav = await getTranslations("nav");
   const tSettings = await getTranslations("settingsPage");
   const { userId } = await requireAuth();
+  const baseUrl = resolveBaseUrl({
+    headerHost: headersList.get("x-forwarded-host") ?? headersList.get("host"),
+    headerProtocol: headersList.get("x-forwarded-proto"),
+  });
   const [clients, recentEvents] = await Promise.all([
     listAgentClientsForUser(userId),
     listRecentAgentAuditEventsForUser(userId),
@@ -31,6 +60,7 @@ export default async function SettingsPage() {
       <AgentSettingsPanel
         initialClients={clients}
         initialRecentEvents={recentEvents}
+        baseUrl={baseUrl}
       />
     </div>
   );

--- a/src/features/settings/components/__tests__/agent-onboarding-panel.test.tsx
+++ b/src/features/settings/components/__tests__/agent-onboarding-panel.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { ReactNode } from "react";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => {
+    const translations: Record<string, string> = {
+      "agents.onboarding.title": "Onboarding por proveedor",
+      "agents.onboarding.description": "Descripción onboarding",
+      "agents.onboarding.baseUrlLabel": "Base URL detectada",
+      "agents.onboarding.repoPathLabel": "Ruta local a sustituir",
+      "agents.onboarding.repoPathHelp": "Sustituye esta ruta por la real.",
+      "agents.onboarding.liveToken": "Incluye el último token.",
+      "agents.onboarding.placeholderToken": "Usa <TOKEN>.",
+      "agents.onboarding.copy": "Copiar",
+      "agents.onboarding.copied": "Copiado",
+      "agents.onboarding.snippetLabel.command": "Comando listo para pegar",
+      "agents.onboarding.snippetLabel.json": "Configuración JSON",
+      "agents.onboarding.snippetLabel.env": "Variables comunes",
+      "agents.onboarding.snippetLabel.curl": "Smoke test de la Agent API",
+      "agents.onboarding.provider.codex.title": "Codex",
+      "agents.onboarding.provider.codex.description": "Registra el MCP desde Codex.",
+      "agents.onboarding.provider.claude.title": "Claude Code",
+      "agents.onboarding.provider.claude.description": "Registra el MCP desde Claude Code.",
+      "agents.onboarding.provider.cursor.title": "Cursor",
+      "agents.onboarding.provider.cursor.description": "Pega este bloque en Cursor.",
+      "agents.onboarding.provider.generic.title": "Cliente MCP genérico",
+      "agents.onboarding.provider.generic.description": "Usa una plantilla genérica.",
+    };
+
+    return translations[key] ?? key;
+  },
+}));
+
+vi.mock("@/features/shared/components/button", () => ({
+  Button: ({ children }: { children: ReactNode }) => <button>{children}</button>,
+}));
+
+import { AgentOnboardingPanel } from "../agent-onboarding-panel";
+
+describe("AgentOnboardingPanel", () => {
+  it("renders the default Codex onboarding with detected values", () => {
+    const html = renderToStaticMarkup(
+      <AgentOnboardingPanel
+        baseUrl="https://rollorian-books.vercel.app"
+        token="rla_live_token"
+        repoRootPlaceholder="/absolute/path/to/rollorian-books"
+        serverName="rollorian-books"
+      />,
+    );
+
+    expect(html).toContain("Onboarding por proveedor");
+    expect(html).toContain("https://rollorian-books.vercel.app");
+    expect(html).toContain("/absolute/path/to/rollorian-books");
+    expect(html).toContain("codex mcp add rollorian-books");
+    expect(html).toContain("ROLLORIAN_AGENT_TOKEN=rla_live_token");
+  });
+});

--- a/src/features/settings/components/agent-onboarding-panel.tsx
+++ b/src/features/settings/components/agent-onboarding-panel.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/features/shared/components/button";
+import {
+  AGENT_ONBOARDING_PROVIDERS,
+  buildAgentOnboardingSnippets,
+  type AgentOnboardingProvider,
+} from "@/lib/agents/onboarding";
+
+interface AgentOnboardingPanelProps {
+  baseUrl: string;
+  token: string | null;
+  repoRootPlaceholder: string;
+  serverName: string;
+}
+
+interface CodeBlockProps {
+  label: string;
+  code: string;
+  copyLabel: string;
+  copiedLabel: string;
+  copyKey: string;
+  copiedKey: string | null;
+  onCopy: (key: string, value: string) => Promise<void>;
+}
+
+function CodeBlock({
+  label,
+  code,
+  copyLabel,
+  copiedLabel,
+  copyKey,
+  copiedKey,
+  onCopy,
+}: CodeBlockProps) {
+  return (
+    <div className="grid gap-2 rounded-[var(--radius-lg)] border border-line bg-surface-soft p-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted">{label}</p>
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          onClick={() => void onCopy(copyKey, code)}
+        >
+          {copiedKey === copyKey ? copiedLabel : copyLabel}
+        </Button>
+      </div>
+      <pre className="overflow-x-auto rounded-[var(--radius-sm)] bg-black/30 px-3 py-3 text-xs text-white">
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
+}
+
+export function AgentOnboardingPanel({
+  baseUrl,
+  token,
+  repoRootPlaceholder,
+  serverName,
+}: AgentOnboardingPanelProps) {
+  const t = useTranslations("settingsPage");
+  const [selectedProvider, setSelectedProvider] = useState<AgentOnboardingProvider>("codex");
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
+
+  const snippets = useMemo(() => buildAgentOnboardingSnippets({
+    baseUrl,
+    token,
+    repoRootPlaceholder,
+    serverName,
+  }), [baseUrl, token, repoRootPlaceholder, serverName]);
+
+  const currentSnippet = snippets.find((entry) => entry.provider === selectedProvider) ?? snippets[0];
+  const hasLiveToken = Boolean(token?.trim());
+
+  async function handleCopy(key: string, value: string) {
+    if (typeof navigator === "undefined" || !navigator.clipboard) {
+      return;
+    }
+
+    await navigator.clipboard.writeText(value);
+    setCopiedKey(key);
+    window.setTimeout(() => {
+      setCopiedKey((current) => current === key ? null : current);
+    }, 2000);
+  }
+
+  return (
+    <div className="grid gap-4 rounded-[var(--radius-lg)] border border-line bg-surface-soft p-5">
+      <div className="grid gap-1">
+        <h3 className="text-lg font-semibold text-on-surface">{t("agents.onboarding.title")}</h3>
+        <p className="text-sm text-muted">{t("agents.onboarding.description")}</p>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <div className="rounded-[var(--radius-md)] border border-line bg-surface px-4 py-3 text-sm text-on-surface-variant">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted">
+            {t("agents.onboarding.baseUrlLabel")}
+          </p>
+          <p className="mt-2 font-mono text-xs text-on-surface">{baseUrl}</p>
+        </div>
+        <div className="rounded-[var(--radius-md)] border border-line bg-surface px-4 py-3 text-sm text-on-surface-variant">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted">
+            {t("agents.onboarding.repoPathLabel")}
+          </p>
+          <p className="mt-2 font-mono text-xs text-on-surface">{repoRootPlaceholder}</p>
+        </div>
+      </div>
+
+      <div className="rounded-[var(--radius-md)] border border-dashed border-line px-4 py-3 text-sm text-muted">
+        {t("agents.onboarding.repoPathHelp")}
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {AGENT_ONBOARDING_PROVIDERS.map((provider) => {
+          const isActive = provider === selectedProvider;
+          return (
+            <button
+              key={provider}
+              type="button"
+              aria-pressed={isActive}
+              onClick={() => setSelectedProvider(provider)}
+              className={[
+                "rounded-full border px-4 py-2 text-sm font-medium transition-colors",
+                isActive
+                  ? "border-accent/40 bg-accent/15 text-on-surface"
+                  : "border-line bg-surface text-muted hover:text-on-surface",
+              ].join(" ")}
+            >
+              {t(`agents.onboarding.provider.${provider}.title`)}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="grid gap-3 rounded-[var(--radius-lg)] border border-line bg-surface p-4">
+        <div className="grid gap-1">
+          <p className="text-base font-semibold text-on-surface">
+            {t(`agents.onboarding.provider.${selectedProvider}.title`)}
+          </p>
+          <p className="text-sm text-muted">
+            {t(`agents.onboarding.provider.${selectedProvider}.description`)}
+          </p>
+        </div>
+
+        <p className={`text-xs ${hasLiveToken ? "text-emerald-300" : "text-amber-300"}`}>
+          {hasLiveToken ? t("agents.onboarding.liveToken") : t("agents.onboarding.placeholderToken")}
+        </p>
+
+        <CodeBlock
+          label={t(`agents.onboarding.snippetLabel.${currentSnippet.primaryLabel}`)}
+          code={currentSnippet.primarySnippet}
+          copyLabel={t("agents.onboarding.copy")}
+          copiedLabel={t("agents.onboarding.copied")}
+          copyKey={`${selectedProvider}:primary`}
+          copiedKey={copiedKey}
+          onCopy={handleCopy}
+        />
+
+        {currentSnippet.secondarySnippet && currentSnippet.secondaryLabel ? (
+          <CodeBlock
+            label={t(`agents.onboarding.snippetLabel.${currentSnippet.secondaryLabel}`)}
+            code={currentSnippet.secondarySnippet}
+            copyLabel={t("agents.onboarding.copy")}
+            copiedLabel={t("agents.onboarding.copied")}
+            copyKey={`${selectedProvider}:secondary`}
+            copiedKey={copiedKey}
+            onCopy={handleCopy}
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/features/settings/components/agent-onboarding-panel.tsx
+++ b/src/features/settings/components/agent-onboarding-panel.tsx
@@ -72,7 +72,12 @@ export function AgentOnboardingPanel({
     serverName,
   }), [baseUrl, token, repoRootPlaceholder, serverName]);
 
-  const currentSnippet = snippets.find((entry) => entry.provider === selectedProvider) ?? snippets[0];
+  const defaultSnippet = snippets[0];
+  if (!defaultSnippet) {
+    return null;
+  }
+
+  const currentSnippet = snippets.find((entry) => entry.provider === selectedProvider) ?? defaultSnippet;
   const hasLiveToken = Boolean(token?.trim());
 
   async function handleCopy(key: string, value: string) {

--- a/src/features/settings/components/agent-settings-panel.tsx
+++ b/src/features/settings/components/agent-settings-panel.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/features/shared/components/button";
+import { AgentOnboardingPanel } from "./agent-onboarding-panel";
 import {
   AGENT_CLIENT_KINDS,
   AGENT_SCOPES,
@@ -14,7 +15,7 @@ import {
   revokeAgentClient,
   revokeAgentCredential,
 } from "@/lib/api/agents";
-import type { AgentAuditEventSummary, AgentClientSummary } from "@/lib/types/agent";
+import type { AgentAuditEventSummary, AgentClientSummary } from "@/lib/agents/types";
 
 function formatDate(value: string | null, emptyLabel: string): string {
   if (!value) {
@@ -45,14 +46,17 @@ function statusClasses(status: "ACTIVE" | "REVOKED" | "SUCCESS" | "FAILURE" | "R
 interface AgentSettingsPanelProps {
   initialClients: AgentClientSummary[];
   initialRecentEvents: AgentAuditEventSummary[];
+  baseUrl: string;
 }
 
 export function AgentSettingsPanel({
   initialClients,
   initialRecentEvents,
+  baseUrl,
 }: AgentSettingsPanelProps) {
   const t = useTranslations("settingsPage");
   const [clients, setClients] = useState(initialClients);
+  const [recentEvents, setRecentEvents] = useState(initialRecentEvents);
   const [connectionName, setConnectionName] = useState("");
   const [connectionKind, setConnectionKind] = useState<(typeof AGENT_CLIENT_KINDS)[number]>("PRIVATE_COMPANION");
   const [selectedScopes, setSelectedScopes] = useState<AgentScope[]>([
@@ -111,6 +115,7 @@ export function AgentSettingsPanel({
         });
 
         updateClient(result.client);
+        setRecentEvents(result.recentEvents);
         setLatestToken({ label: result.client.name, token: result.plainToken ?? "" });
         resetCreateForm();
       } catch (caught) {
@@ -129,6 +134,7 @@ export function AgentSettingsPanel({
       });
 
       updateClient(result.client);
+      setRecentEvents(result.recentEvents);
       setLatestToken({ label: client.name, token: result.plainToken ?? "" });
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : t("errors.generic"));
@@ -144,6 +150,7 @@ export function AgentSettingsPanel({
     try {
       const result = await revokeAgentClient(client.id);
       updateClient(result.client);
+      setRecentEvents(result.recentEvents);
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : t("errors.generic"));
     } finally {
@@ -158,6 +165,7 @@ export function AgentSettingsPanel({
     try {
       const result = await revokeAgentCredential(clientId, credentialId);
       updateClient(result.client);
+      setRecentEvents(result.recentEvents);
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : t("errors.generic"));
     } finally {
@@ -299,17 +307,12 @@ export function AgentSettingsPanel({
             </div>
           )}
 
-          <div className="grid gap-2 rounded-[var(--radius-lg)] border border-line bg-surface-soft p-4 text-sm text-on-surface-variant">
-            <p className="font-semibold text-on-surface">{t("agents.instructions.title")}</p>
-            <p>{t("agents.instructions.api")}</p>
-            <pre className="overflow-x-auto rounded-[var(--radius-sm)] bg-black/30 px-3 py-3 text-xs text-white">
-              <code>{`curl -H "Authorization: Bearer <TOKEN>" https://your-rollorian.vercel.app/api/agent/v1/summary`}</code>
-            </pre>
-            <p>{t("agents.instructions.mcp")}</p>
-            <pre className="overflow-x-auto rounded-[var(--radius-sm)] bg-black/30 px-3 py-3 text-xs text-white">
-              <code>{`ROLLORIAN_BASE_URL=https://your-rollorian.vercel.app\nROLLORIAN_AGENT_TOKEN=<TOKEN>`}</code>
-            </pre>
-          </div>
+          <AgentOnboardingPanel
+            baseUrl={baseUrl}
+            token={latestToken?.token ?? null}
+            repoRootPlaceholder="/absolute/path/to/rollorian-books"
+            serverName="rollorian-books"
+          />
         </section>
       </div>
 
@@ -424,13 +427,13 @@ export function AgentSettingsPanel({
           <p className="text-sm text-muted">{t("agents.activity.description")}</p>
         </div>
 
-        {initialRecentEvents.length === 0 ? (
+        {recentEvents.length === 0 ? (
           <div className="rounded-[var(--radius-lg)] border border-dashed border-line px-5 py-8 text-sm text-muted">
             {t("agents.activity.empty")}
           </div>
         ) : (
           <div className="grid gap-2">
-            {initialRecentEvents.map((event) => (
+            {recentEvents.map((event) => (
               <div
                 key={event.id}
                 className="grid gap-2 rounded-[var(--radius-md)] border border-line bg-surface-soft px-4 py-3 md:grid-cols-[auto_1fr_auto]"

--- a/src/lib/agents/__tests__/onboarding.test.ts
+++ b/src/lib/agents/__tests__/onboarding.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { buildAgentOnboardingSnippets } from "@/lib/agents/onboarding";
+
+describe("buildAgentOnboardingSnippets", () => {
+  it("builds provider-specific snippets with a live token", () => {
+    const snippets = buildAgentOnboardingSnippets({
+      baseUrl: "https://rollorian-books.vercel.app",
+      token: "rla_secret_token",
+      repoRootPlaceholder: "/absolute/path/to/rollorian-books",
+      serverName: "rollorian-books",
+    });
+
+    expect(snippets).toHaveLength(4);
+    expect(snippets[0]?.primarySnippet).toContain("codex mcp add rollorian-books");
+    expect(snippets[0]?.primarySnippet).toContain("ROLLORIAN_AGENT_TOKEN=rla_secret_token");
+    expect(snippets[1]?.primarySnippet).toContain("claude mcp add --transport stdio");
+    expect(snippets[2]?.primarySnippet).toContain('"type": "stdio"');
+    expect(snippets[2]?.primarySnippet).toContain('"ROLLORIAN_BASE_URL": "https://rollorian-books.vercel.app"');
+    expect(snippets[3]?.secondarySnippet).toContain("curl -H \"Authorization: Bearer rla_secret_token\"");
+  });
+
+  it("falls back to the token placeholder when no live token exists", () => {
+    const snippets = buildAgentOnboardingSnippets({
+      baseUrl: "https://rollorian-books.vercel.app",
+      token: null,
+      repoRootPlaceholder: "/absolute/path/to/rollorian-books",
+      serverName: "rollorian-books",
+    });
+
+    for (const snippet of snippets) {
+      expect(snippet.primarySnippet).toContain("<TOKEN>");
+    }
+  });
+});

--- a/src/lib/agents/index.ts
+++ b/src/lib/agents/index.ts
@@ -3,6 +3,7 @@ export { agentReadingEventRequestSchema, createAgentClientSchema, issueAgentCred
 export { AgentAuthError, AgentConflictError, AgentInputError, AgentNotFoundError, AgentRateLimitError, AgentScopeError } from "./errors";
 export { type AgentOwner, type AgentContext, requireAgentScope, resolveAgentRequestContext } from "./context";
 export { createAgentToken, hashAgentToken } from "./tokens";
+export { type AgentAuditEventSummary, type AgentClientMutationResponse, type AgentClientSummary, type AgentConnectionsResponse, type AgentCredentialSummary } from "./types";
 export { listAgentClientsForUser, listRecentAgentAuditEventsForUser, createAgentClientForUser, issueAgentCredentialForUser, revokeAgentCredentialForUser, revokeAgentClientForUser } from "./management";
 export { getAgentProfile, getAgentSummary, getAgentLibrarySnapshot, getAgentLists, getAgentRecommendations, resolveAgentBook, applyAgentReadingEvent } from "./service";
 export { handleAgentRoute } from "./http";

--- a/src/lib/agents/management.ts
+++ b/src/lib/agents/management.ts
@@ -9,7 +9,7 @@ import { createAgentToken } from "./tokens";
 import type {
   AgentAuditEventSummary,
   AgentClientSummary,
-} from "@/lib/types/agent";
+} from "./types";
 
 type AgentClientWithRelations = Prisma.AgentClientGetPayload<{
   include: {

--- a/src/lib/agents/onboarding.ts
+++ b/src/lib/agents/onboarding.ts
@@ -1,0 +1,107 @@
+export const AGENT_ONBOARDING_PROVIDERS = [
+  "codex",
+  "claude",
+  "cursor",
+  "generic",
+] as const;
+
+export type AgentOnboardingProvider = (typeof AGENT_ONBOARDING_PROVIDERS)[number];
+
+export type AgentOnboardingSnippet = {
+  provider: AgentOnboardingProvider;
+  primaryLabel: "command" | "json";
+  primarySnippet: string;
+  secondaryLabel?: "json" | "env" | "curl";
+  secondarySnippet?: string;
+};
+
+export type BuildAgentOnboardingOptions = {
+  baseUrl: string;
+  token: string | null;
+  repoRootPlaceholder: string;
+  serverName: string;
+};
+
+const TOKEN_PLACEHOLDER = "<TOKEN>";
+
+function createEnvBlock(baseUrl: string, token: string) {
+  return [
+    `ROLLORIAN_BASE_URL=${baseUrl}`,
+    `ROLLORIAN_AGENT_TOKEN=${token}`,
+  ].join("\n");
+}
+
+function createCursorConfig(pathToMcp: string, baseUrl: string, token: string, serverName: string) {
+  return JSON.stringify({
+    mcpServers: {
+      [serverName]: {
+        type: "stdio",
+        command: "npm",
+        args: ["--prefix", pathToMcp, "run", "dev:stdio"],
+        env: {
+          ROLLORIAN_BASE_URL: baseUrl,
+          ROLLORIAN_AGENT_TOKEN: token,
+        },
+      },
+    },
+  }, null, 2);
+}
+
+function createGenericConfig(pathToMcp: string, baseUrl: string, token: string) {
+  return JSON.stringify({
+    command: "npm",
+    args: ["--prefix", pathToMcp, "run", "dev:stdio"],
+    env: {
+      ROLLORIAN_BASE_URL: baseUrl,
+      ROLLORIAN_AGENT_TOKEN: token,
+    },
+  }, null, 2);
+}
+
+export function buildAgentOnboardingSnippets({
+  baseUrl,
+  token,
+  repoRootPlaceholder,
+  serverName,
+}: BuildAgentOnboardingOptions): AgentOnboardingSnippet[] {
+  const resolvedToken = token?.trim() || TOKEN_PLACEHOLDER;
+  const pathToMcp = `${repoRootPlaceholder}/mcp/rollorian-mcp`;
+  const envBlock = createEnvBlock(baseUrl, resolvedToken);
+
+  return [
+    {
+      provider: "codex",
+      primaryLabel: "command",
+      primarySnippet: [
+        `codex mcp add ${serverName} --env ROLLORIAN_BASE_URL=${baseUrl} --env ROLLORIAN_AGENT_TOKEN=${resolvedToken} -- npm --prefix ${pathToMcp} run dev:stdio`,
+        "codex mcp list",
+      ].join("\n"),
+      secondaryLabel: "env",
+      secondarySnippet: envBlock,
+    },
+    {
+      provider: "claude",
+      primaryLabel: "command",
+      primarySnippet: [
+        `claude mcp add --transport stdio --env ROLLORIAN_BASE_URL=${baseUrl} --env ROLLORIAN_AGENT_TOKEN=${resolvedToken} ${serverName} -- npm --prefix ${pathToMcp} run dev:stdio`,
+        "claude mcp list",
+      ].join("\n"),
+      secondaryLabel: "env",
+      secondarySnippet: envBlock,
+    },
+    {
+      provider: "cursor",
+      primaryLabel: "json",
+      primarySnippet: createCursorConfig(pathToMcp, baseUrl, resolvedToken, serverName),
+      secondaryLabel: "env",
+      secondarySnippet: envBlock,
+    },
+    {
+      provider: "generic",
+      primaryLabel: "json",
+      primarySnippet: createGenericConfig(pathToMcp, baseUrl, resolvedToken),
+      secondaryLabel: "curl",
+      secondarySnippet: `curl -H "Authorization: Bearer ${resolvedToken}" ${baseUrl}/api/agent/v1/summary`,
+    },
+  ];
+}

--- a/src/lib/agents/types.ts
+++ b/src/lib/agents/types.ts
@@ -1,0 +1,44 @@
+import type { AgentClientKind, AgentScope } from "@/lib/agents/constants";
+
+export type AgentCredentialSummary = {
+  id: string;
+  tokenPrefix: string;
+  scopes: AgentScope[];
+  createdAt: string;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  lastUsedAt: string | null;
+};
+
+export type AgentAuditEventSummary = {
+  id: string;
+  action: string;
+  outcome: "SUCCESS" | "FAILURE" | "REJECTED";
+  resourceType: string | null;
+  resourceId: string | null;
+  idempotencyKey: string | null;
+  createdAt: string;
+};
+
+export type AgentClientSummary = {
+  id: string;
+  name: string;
+  kind: AgentClientKind;
+  status: "ACTIVE" | "REVOKED";
+  createdAt: string;
+  updatedAt: string;
+  lastUsedAt: string | null;
+  credentials: AgentCredentialSummary[];
+  recentEvents: AgentAuditEventSummary[];
+};
+
+export type AgentConnectionsResponse = {
+  clients: AgentClientSummary[];
+  recentEvents: AgentAuditEventSummary[];
+};
+
+export type AgentClientMutationResponse = {
+  client: AgentClientSummary;
+  recentEvents: AgentAuditEventSummary[];
+  plainToken?: string;
+};

--- a/src/lib/api/agents.ts
+++ b/src/lib/api/agents.ts
@@ -5,7 +5,7 @@ import type {
 import type {
   AgentClientMutationResponse,
   AgentConnectionsResponse,
-} from "@/lib/types/agent";
+} from "@/lib/agents/types";
 import { apiFetch } from "./client";
 
 export async function fetchAgentConnections(): Promise<AgentConnectionsResponse> {
@@ -45,4 +45,3 @@ export async function revokeAgentCredential(
     method: "POST",
   });
 }
-

--- a/src/lib/types/agent.ts
+++ b/src/lib/types/agent.ts
@@ -1,44 +1,7 @@
-import type { AgentClientKind, AgentScope } from "@/lib/agents/constants";
-
-export type AgentCredentialSummary = {
-  id: string;
-  tokenPrefix: string;
-  scopes: AgentScope[];
-  createdAt: string;
-  expiresAt: string | null;
-  revokedAt: string | null;
-  lastUsedAt: string | null;
-};
-
-export type AgentAuditEventSummary = {
-  id: string;
-  action: string;
-  outcome: "SUCCESS" | "FAILURE" | "REJECTED";
-  resourceType: string | null;
-  resourceId: string | null;
-  idempotencyKey: string | null;
-  createdAt: string;
-};
-
-export type AgentClientSummary = {
-  id: string;
-  name: string;
-  kind: AgentClientKind;
-  status: "ACTIVE" | "REVOKED";
-  createdAt: string;
-  updatedAt: string;
-  lastUsedAt: string | null;
-  credentials: AgentCredentialSummary[];
-  recentEvents: AgentAuditEventSummary[];
-};
-
-export type AgentConnectionsResponse = {
-  clients: AgentClientSummary[];
-  recentEvents: AgentAuditEventSummary[];
-};
-
-export type AgentClientMutationResponse = {
-  client: AgentClientSummary;
-  plainToken?: string;
-};
-
+export type {
+  AgentAuditEventSummary,
+  AgentClientMutationResponse,
+  AgentClientSummary,
+  AgentConnectionsResponse,
+  AgentCredentialSummary,
+} from "@/lib/agents/types";


### PR DESCRIPTION
## Summary
- bootstrap OpenSpec in Books and standardize the agent management mutation contract
- add provider-specific MCP onboarding for Codex, Claude Code, Cursor, and generic stdio clients in Settings
- add route and onboarding tests so the self-service flow stays covered before TODO mirrors the pattern

## Validation
- ✅ `npm run lint:strict`
- ✅ `npm run test:run`
- ✅ `npm run test:coverage`
- ⚠️ `npm run test:e2e` is currently blocked in this local environment because Books E2E requires a reachable seeded PostgreSQL test DB; the app fails in `require-auth.ts` with Prisma `ECONNREFUSED` before the existing navigation/library/search specs can run

## Manual validation requested
- generate a connection and confirm the token is shown once
- copy a provider snippet (Codex/Claude/Cursor/generic) and verify the MCP config is correct
- rotate/revoke and confirm the recent activity list stays in sync
- confirm unrelated library/search/navigation behavior still works before merge